### PR TITLE
Fixes for install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -35,3 +35,4 @@ include changelogs/CHANGELOG*.rst
 include changelogs/changelog.yaml
 recursive-include hacking/build_library *.py
 include hacking/build-ansible.py
+include mypy.ini

--- a/docs/docsite/rst/dev_guide/testing/sanity/mypy.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/mypy.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+mypy
+====
+
+A type checker running against Pyhton 3.9, 3.6 and 2.7. At
+the moment it only runs agains a few subpackages and not the
+whole project.
+See https://mypy.rtfd.io for more details on how type
+annotations in Python work.

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1357,10 +1357,23 @@ class GalaxyCLI(CLI):
                     continue
 
                 collection_found = True
-                collection = Requirement.from_dir_path_as_installed(
-                    b_collection_path, artifacts_manager,
-                )
-                fqcn_width, version_width = _get_collection_widths(collection)
+
+                b_manifest_path = os.path.join(b_collection_path, b'MANIFEST.json')
+                b_galaxy_yml_path = os.path.join(b_collection_path, b'galaxy.yml')
+
+                if os.path.exists(b_manifest_path):
+                    collection = Requirement.from_dir_path_as_installed(
+                        b_collection_path, artifacts_manager,
+                    )
+                elif os.path.exists(b_galaxy_yml_path):
+                    collection = Requirement.from_dir_path_as_dev(
+                        b_collection_path, artifacts_manager,
+                    )
+                else:
+                    collection = Requirement.from_dir_path_as_unknown(
+                        b_collection_path,
+                    )
+                fqcn_width, version_width = _get_collection_widths([collection])
 
                 _display_header(collection_path, 'Collection', 'Version', fqcn_width, version_width)
                 _display_collection(collection, fqcn_width, version_width)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1358,21 +1358,14 @@ class GalaxyCLI(CLI):
 
                 collection_found = True
 
-                b_manifest_path = os.path.join(b_collection_path, b'MANIFEST.json')
-                b_galaxy_yml_path = os.path.join(b_collection_path, b'galaxy.yml')
-
-                if os.path.exists(b_manifest_path):
-                    collection = Requirement.from_dir_path_as_installed(
-                        b_collection_path, artifacts_manager,
-                    )
-                elif os.path.exists(b_galaxy_yml_path):
-                    collection = Requirement.from_dir_path_as_dev(
-                        b_collection_path, artifacts_manager,
-                    )
-                else:
+                try:
                     collection = Requirement.from_dir_path_as_unknown(
                         b_collection_path,
+                        artifacts_manager,
                     )
+                except ValueError as val_err:
+                    six.raise_from(AnsibleError(val_err), val_err)
+
                 fqcn_width, version_width = _get_collection_widths([collection])
 
                 _display_header(collection_path, 'Collection', 'Version', fqcn_width, version_width)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -24,7 +24,6 @@ from ansible.galaxy import Galaxy, get_collections_galaxy_meta_info
 from ansible.galaxy.api import GalaxyAPI
 from ansible.galaxy.collection import (
     build_collection,
-    CollectionRequirement,
     download_collections,
     find_existing_collections,
     install_collections,
@@ -33,6 +32,10 @@ from ansible.galaxy.collection import (
     validate_collection_path,
     verify_collections
 )
+from ansible.galaxy.collection.concrete_artifact_manager import (
+    ConcreteArtifactsManager,
+)
+from ansible.galaxy.dependency_resolution.dataclasses import Requirement
 
 from ansible.galaxy.role import GalaxyRole
 from ansible.galaxy.token import BasicAuthToken, GalaxyToken, KeycloakToken, NoTokenSentinel
@@ -49,6 +52,20 @@ from ansible.utils.plugin_docs import get_versioned_doclink
 
 display = Display()
 urlparse = six.moves.urllib.parse.urlparse
+
+
+def with_collection_artifacts_manager(wrapped_method):
+    def method_wrapper(*args, **kwargs):
+        if 'artifacts_manager' in kwargs:
+            return wrapped_method(*args, **kwargs)
+
+        with ConcreteArtifactsManager.under_tmpdir(
+                C.DEFAULT_LOCAL_TMP,
+                validate_certs=not context.CLIARGS['ignore_certs'],
+        ) as concrete_artifact_cm:
+            kwargs['artifacts_manager'] = concrete_artifact_cm
+            return wrapped_method(*args, **kwargs)
+    return method_wrapper
 
 
 def _display_header(path, h1, h2, w1=10, w2=7):
@@ -75,20 +92,19 @@ def _display_role(gr):
 
 def _display_collection(collection, cwidth=10, vwidth=7, min_cwidth=10, min_vwidth=7):
     display.display('{fqcn:{cwidth}} {version:{vwidth}}'.format(
-        fqcn=to_text(collection),
-        version=collection.latest_version,
+        fqcn=to_text(collection.fqcn),
+        version=collection.ver,
         cwidth=max(cwidth, min_cwidth),  # Make sure the width isn't smaller than the header
         vwidth=max(vwidth, min_vwidth)
     ))
 
 
 def _get_collection_widths(collections):
-    if is_iterable(collections):
-        fqcn_set = set(to_text(c) for c in collections)
-        version_set = set(to_text(c.latest_version) for c in collections)
-    else:
-        fqcn_set = set([to_text(collections)])
-        version_set = set([collections.latest_version])
+    if not is_iterable(collections):
+        collections = (collections, )
+
+    fqcn_set = {to_text(c.fqcn) for c in collections}
+    version_set = {to_text(c.ver) for c in collections}
 
     fqcn_length = len(max(fqcn_set, key=len))
     version_length = len(max(version_set, key=len))
@@ -528,7 +544,7 @@ class GalaxyCLI(CLI):
     def _get_default_collection_path(self):
         return C.COLLECTIONS_PATHS[0]
 
-    def _parse_requirements_file(self, requirements_file, allow_old_format=True):
+    def _parse_requirements_file(self, requirements_file, allow_old_format=True, artifacts_manager=None):
         """
         Parses an Ansible requirement.yml file and returns all the roles and/or collections defined in it. There are 2
         requirements file format:
@@ -617,30 +633,14 @@ class GalaxyCLI(CLI):
             for role_req in file_requirements.get('roles') or []:
                 requirements['roles'] += parse_role_req(role_req)
 
-            for collection_req in file_requirements.get('collections') or []:
-                if isinstance(collection_req, dict):
-                    req_name = collection_req.get('name', None)
-                    if req_name is None:
-                        raise AnsibleError("Collections requirement entry should contain the key name.")
-
-                    req_type = collection_req.get('type')
-                    if req_type not in ('file', 'galaxy', 'git', 'url', None):
-                        raise AnsibleError("The collection requirement entry key 'type' must be one of file, galaxy, git, or url.")
-
-                    req_version = collection_req.get('version', '*')
-                    req_source = collection_req.get('source', None)
-                    if req_source:
-                        # Try and match up the requirement source with our list of Galaxy API servers defined in the
-                        # config, otherwise create a server with that URL without any auth.
-                        req_source = next(iter([a for a in self.api_servers if req_source in [a.name, a.api_server]]),
-                                          GalaxyAPI(self.galaxy,
-                                                    "explicit_requirement_%s" % req_name,
-                                                    req_source,
-                                                    validate_certs=not context.CLIARGS['ignore_certs']))
-
-                    requirements['collections'].append((req_name, req_version, req_source, req_type))
-                else:
-                    requirements['collections'].append((collection_req, '*', None, None))
+            requirements['collections'] = [
+                Requirement.from_requirement_dict(
+                    collection_req if isinstance(collection_req, dict)
+                    else {'name': collection_req},
+                    artifacts_manager,
+                )
+                for collection_req in file_requirements.get('collections', [])
+            ]
 
         return requirements
 
@@ -731,26 +731,29 @@ class GalaxyCLI(CLI):
 
         return meta_value
 
-    def _require_one_of_collections_requirements(self, collections, requirements_file):
+    def _require_one_of_collections_requirements(
+            self, collections, requirements_file,
+            artifacts_manager=None,
+    ):
         if collections and requirements_file:
             raise AnsibleError("The positional collection_name arg and --requirements-file are mutually exclusive.")
         elif not collections and not requirements_file:
             raise AnsibleError("You must specify a collection name or a requirements file.")
         elif requirements_file:
             requirements_file = GalaxyCLI._resolve_path(requirements_file)
-            requirements = self._parse_requirements_file(requirements_file, allow_old_format=False)
+            requirements = self._parse_requirements_file(
+                requirements_file,
+                allow_old_format=False,
+                artifacts_manager=artifacts_manager,
+            )
         else:
-            requirements = {'collections': [], 'roles': []}
-            for collection_input in collections:
-                requirement = None
-                if os.path.isfile(to_bytes(collection_input, errors='surrogate_or_strict')) or \
-                        urlparse(collection_input).scheme.lower() in ['http', 'https'] or \
-                        collection_input.startswith(('git+', 'git@')):
-                    # Arg is a file path or URL to a collection
-                    name = collection_input
-                else:
-                    name, dummy, requirement = collection_input.partition(':')
-                requirements['collections'].append((name, requirement or '*', None, None))
+            requirements = {
+                'collections': [
+                    Requirement.from_string(coll_input, artifacts_manager)
+                    for coll_input in collections
+                ],
+                'roles': [],
+            }
         return requirements
 
     ############################
@@ -792,25 +795,31 @@ class GalaxyCLI(CLI):
             collection_path = GalaxyCLI._resolve_path(collection_path)
             build_collection(collection_path, output_path, force)
 
-    def execute_download(self):
+    @with_collection_artifacts_manager
+    def execute_download(self, artifacts_manager=None):
         collections = context.CLIARGS['args']
         no_deps = context.CLIARGS['no_deps']
         download_path = context.CLIARGS['download_path']
-        ignore_certs = context.CLIARGS['ignore_certs']
 
         requirements_file = context.CLIARGS['requirements']
         if requirements_file:
             requirements_file = GalaxyCLI._resolve_path(requirements_file)
 
-        requirements = self._require_one_of_collections_requirements(collections, requirements_file)['collections']
+        requirements = self._require_one_of_collections_requirements(
+            collections, requirements_file,
+            artifacts_manager=artifacts_manager,
+        )['collections']
 
         download_path = GalaxyCLI._resolve_path(download_path)
         b_download_path = to_bytes(download_path, errors='surrogate_or_strict')
         if not os.path.exists(b_download_path):
             os.makedirs(b_download_path)
 
-        download_collections(requirements, download_path, self.api_servers, (not ignore_certs), no_deps,
-                             context.CLIARGS['allow_pre_release'])
+        download_collections(
+            requirements, download_path, self.api_servers, no_deps,
+            context.CLIARGS['allow_pre_release'],
+            artifacts_manager=artifacts_manager,
+        )
 
         return 0
 
@@ -1000,24 +1009,31 @@ class GalaxyCLI(CLI):
 
         self.pager(data)
 
-    def execute_verify(self):
+    @with_collection_artifacts_manager
+    def execute_verify(self, artifacts_manager=None):
 
         collections = context.CLIARGS['args']
         search_paths = context.CLIARGS['collections_path']
-        ignore_certs = context.CLIARGS['ignore_certs']
         ignore_errors = context.CLIARGS['ignore_errors']
         requirements_file = context.CLIARGS['requirements']
 
-        requirements = self._require_one_of_collections_requirements(collections, requirements_file)['collections']
+        requirements = self._require_one_of_collections_requirements(
+            collections, requirements_file,
+            artifacts_manager=artifacts_manager,
+        )['collections']
 
         resolved_paths = [validate_collection_path(GalaxyCLI._resolve_path(path)) for path in search_paths]
 
-        verify_collections(requirements, resolved_paths, self.api_servers, (not ignore_certs), ignore_errors,
-                           allow_pre_release=True)
+        verify_collections(
+            requirements, resolved_paths, self.api_servers,
+            ignore_errors, allow_pre_release=True,
+            artifacts_manager=artifacts_manager,
+        )
 
         return 0
 
-    def execute_install(self):
+    @with_collection_artifacts_manager
+    def execute_install(self, artifacts_manager=None):
         """
         Install one or more roles(``ansible-galaxy role install``), or one or more collections(``ansible-galaxy collection install``).
         You can pass in a list (roles or collections) or use the file
@@ -1040,7 +1056,10 @@ class GalaxyCLI(CLI):
         role_requirements = []
         if context.CLIARGS['type'] == 'collection':
             collection_path = GalaxyCLI._resolve_path(context.CLIARGS['collections_path'])
-            requirements = self._require_one_of_collections_requirements(install_items, requirements_file)
+            requirements = self._require_one_of_collections_requirements(
+                install_items, requirements_file,
+                artifacts_manager=artifacts_manager,
+            )
 
             collection_requirements = requirements['collections']
             if requirements['roles']:
@@ -1053,7 +1072,10 @@ class GalaxyCLI(CLI):
                 if not (requirements_file.endswith('.yaml') or requirements_file.endswith('.yml')):
                     raise AnsibleError("Invalid role requirements file, it must end with a .yml or .yaml extension")
 
-                requirements = self._parse_requirements_file(requirements_file)
+                requirements = self._parse_requirements_file(
+                    requirements_file,
+                    artifacts_manager=artifacts_manager,
+                )
                 role_requirements = requirements['roles']
 
                 # We can only install collections and roles at the same time if the type wasn't specified and the -p
@@ -1088,11 +1110,15 @@ class GalaxyCLI(CLI):
             display.display("Starting galaxy collection install process")
             # Collections can technically be installed even when ansible-galaxy is in role mode so we need to pass in
             # the install path as context.CLIARGS['collections_path'] won't be set (default is calculated above).
-            self._execute_install_collection(collection_requirements, collection_path)
+            self._execute_install_collection(
+                collection_requirements, collection_path,
+                artifacts_manager=artifacts_manager,
+            )
 
-    def _execute_install_collection(self, requirements, path):
+    def _execute_install_collection(
+            self, requirements, path, artifacts_manager,
+    ):
         force = context.CLIARGS['force']
-        ignore_certs = context.CLIARGS['ignore_certs']
         ignore_errors = context.CLIARGS['ignore_errors']
         no_deps = context.CLIARGS['no_deps']
         force_with_deps = context.CLIARGS['force_with_deps']
@@ -1109,8 +1135,12 @@ class GalaxyCLI(CLI):
         if not os.path.exists(b_output_path):
             os.makedirs(b_output_path)
 
-        install_collections(requirements, output_path, self.api_servers, (not ignore_certs), ignore_errors,
-                            no_deps, force, force_with_deps, allow_pre_release=allow_pre_release)
+        install_collections(
+            requirements, output_path, self.api_servers, ignore_errors,
+            no_deps, force, force_with_deps,
+            allow_pre_release=allow_pre_release,
+            artifacts_manager=artifacts_manager,
+        )
 
         return 0
 
@@ -1281,7 +1311,8 @@ class GalaxyCLI(CLI):
 
         return 0
 
-    def execute_list_collection(self):
+    @with_collection_artifacts_manager
+    def execute_list_collection(self, artifacts_manager=None):
         """
         List all collections installed on the local system
         """
@@ -1326,7 +1357,9 @@ class GalaxyCLI(CLI):
                     continue
 
                 collection_found = True
-                collection = CollectionRequirement.from_path(b_collection_path, False, fallback_metadata=True)
+                collection = Requirement.from_dir_path_as_installed(
+                    b_collection_path, artifacts_manager,
+                )
                 fqcn_width, version_width = _get_collection_widths(collection)
 
                 _display_header(collection_path, 'Collection', 'Version', fqcn_width, version_width)
@@ -1337,7 +1370,9 @@ class GalaxyCLI(CLI):
                 collection_path = validate_collection_path(path)
                 if os.path.isdir(collection_path):
                     display.vvv("Searching {0} for collections".format(collection_path))
-                    collections = find_existing_collections(collection_path, fallback_metadata=True)
+                    collections = list(find_existing_collections(
+                        collection_path, artifacts_manager,
+                    ))
                 else:
                     # There was no 'ansible_collections/' directory in the path, so there
                     # or no collections here.
@@ -1353,8 +1388,7 @@ class GalaxyCLI(CLI):
                 _display_header(collection_path, 'Collection', 'Version', fqcn_width, version_width)
 
                 # Sort collections by the namespace and name
-                collections.sort(key=to_text)
-                for collection in collections:
+                for collection in sorted(collections, key=to_text):
                     _display_collection(collection, fqcn_width, version_width)
 
         # Do not warn if the specific collection was found in any of the search paths

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -793,7 +793,7 @@ class GalaxyCLI(CLI):
 
         for collection_path in context.CLIARGS['args']:
             collection_path = GalaxyCLI._resolve_path(collection_path)
-            build_collection(collection_path, output_path, force)
+            build_collection(collection_path, b_output_path, force)
 
     @with_collection_artifacts_manager
     def execute_download(self, artifacts_manager=None):

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -639,7 +639,7 @@ class GalaxyCLI(CLI):
                     else {'name': collection_req},
                     artifacts_manager,
                 )
-                for collection_req in file_requirements.get('collections', [])
+                for collection_req in file_requirements.get('collections') or []
             ]
 
         return requirements

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -7,6 +7,7 @@ __metaclass__ = type
 
 import collections
 import datetime
+import functools
 import hashlib
 import json
 import os
@@ -233,11 +234,17 @@ class CollectionVersionMetadata:
         self.dependencies = dependencies
 
 
+@functools.total_ordering
 class GalaxyAPI:
     """ This class is meant to be used as a API client for an Ansible Galaxy server """
 
-    def __init__(self, galaxy, name, url, username=None, password=None, token=None, validate_certs=True,
-                 available_api_versions=None, clear_response_cache=False, no_cache=True):
+    def __init__(
+            self, galaxy, name, url,
+            username=None, password=None, token=None, validate_certs=True,
+            available_api_versions=None,
+            clear_response_cache=False, no_cache=True,
+            priority=float('inf'),
+    ):
         self.galaxy = galaxy
         self.name = name
         self.username = username
@@ -246,6 +253,7 @@ class GalaxyAPI:
         self.api_server = url
         self.validate_certs = validate_certs
         self._available_api_versions = available_api_versions or {}
+        self._priority = priority
 
         b_cache_dir = to_bytes(C.config.get_config_value('GALAXY_CACHE_DIR'), errors='surrogate_or_strict')
         makedirs_safe(b_cache_dir, mode=0o700)
@@ -282,6 +290,17 @@ class GalaxyAPI:
                 instance=self, name=self.name,
                 priority=self._priority, url=self.api_server,
             )
+        )
+
+    def __lt__(self, other_galaxy_api):
+        # type: (GalaxyAPI, GalaxyAPI) -> Union[bool, 'NotImplemented']
+        """Return whether the instance priority is higher than other."""
+        if not isinstance(other_galaxy_api, self.__class__):
+            return NotImplemented
+
+        return (
+            self._priority > other_galaxy_api._priority or
+            self.name < self.name
         )
 
     @property

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -263,6 +263,16 @@ class GalaxyAPI:
 
         display.debug('Validate TLS certificates for %s: %s' % (self.api_server, self.validate_certs))
 
+    def __str__(self):
+        # type: (GalaxyAPI) -> str
+        """Render GalaxyAPI as a native string representation."""
+        return to_native(self.name)
+
+    def __unicode__(self):
+        # type: (GalaxyAPI) -> unicode
+        """Render GalaxyAPI as a unicode/text string representation."""
+        return to_text(self.name)
+
     @property
     @g_connect(['v1', 'v2', 'v3'])
     def available_api_versions(self):

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -273,6 +273,17 @@ class GalaxyAPI:
         """Render GalaxyAPI as a unicode/text string representation."""
         return to_text(self.name)
 
+    def __repr__(self):
+        # type: (GalaxyAPI) -> str
+        """Render GalaxyAPI as an inspectable string representation."""
+        return (
+            '<{instance!s} "{name!s}" @ {url!s} with priority {priority!s}>'.
+            format(
+                instance=self, name=self.name,
+                priority=self._priority, url=self.api_server,
+            )
+        )
+
     @property
     @g_connect(['v1', 'v2', 'v3'])
     def available_api_versions(self):

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -977,7 +977,23 @@ def find_existing_collections(path, artifacts_manager):
             if not os.path.isdir(b_collection_path):
                 continue
 
-            req = Candidate.from_dir_path_as_installed(b_collection_path, artifacts_manager)
+            b_manifest_path = os.path.join(b_collection_path, b'MANIFEST.json')
+            b_galaxy_yml_path = os.path.join(b_collection_path, b'galaxy.yml')
+
+            if os.path.exists(b_manifest_path):
+                req = Candidate.from_dir_path_as_installed(b_collection_path, artifacts_manager)
+            elif os.path.exists(b_galaxy_yml_path):
+                # allow badly formatted galaxy.yml files?
+                req = Candidate.from_dir_path_as_dev(b_collection_path, artifacts_manager)
+            else:
+                # no metadata was found
+                display.warning(
+                    "Collection at '%s' does not have a MANIFEST.json file, cannot detect version." % to_text(
+                        b_collection_path, errors='surrogate_or_strict'
+                    )
+                )
+                req = Candidate.from_dir_path_as_unknown(b_collection_path)
+
             display.vvv(
                 "Found installed collection {coll!s} at '{path!s}'".
                 format(coll=to_text(req), path=to_text(req.src))

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -9,7 +9,6 @@ __metaclass__ = type
 import errno
 import fnmatch
 import json
-import operator
 import os
 import shutil
 import stat
@@ -25,30 +24,101 @@ from contextlib import contextmanager
 from distutils.version import LooseVersion
 from hashlib import sha256
 from io import BytesIO
+from itertools import chain
 from yaml.error import YAMLError
 
+# NOTE: Adding type ignores is a hack for mypy to shut up wrt bug #1153
 try:
-    import queue
+    import queue  # type: ignore
+except ImportError:  # Python 2
+    import Queue as queue  # type: ignore
+
+try:
+    # NOTE: It's in Python 3 stdlib and can be installed on Python 2
+    # NOTE: via `pip install typing`. Unnecessary in runtime.
+    # NOTE: `TYPE_CHECKING` is True during mypy-typecheck-time.
+    from typing import TYPE_CHECKING
 except ImportError:
-    import Queue as queue  # Python 2
+    TYPE_CHECKING = False
+
+if TYPE_CHECKING:
+    from typing import Dict, Iterable, List, Optional, Text, Union
+    if sys.version_info[:2] >= (3, 8):
+        from typing import Literal
+    else:  # Python 2 + Python 3.4-3.7
+        from typing_extensions import Literal
+
+    from ansible.galaxy.api import GalaxyAPI
+    from ansible.galaxy.collection.concrete_artifact_manager import (
+        ConcreteArtifactsManager,
+    )
+
+    ManifestKeysType = Literal[
+        'collection_info', 'file_manifest_file', 'format',
+    ]
+    FileMetaKeysType = Literal[
+        'name',
+        'ftype',
+        'chksum_type',
+        'chksum_sha256',
+        'format',
+    ]
+    CollectionInfoKeysType = Literal[
+        # collection meta:
+        'namespace', 'name', 'version',
+        'authors', 'readme',
+        'tags', 'description',
+        'license', 'license_file',
+        'dependencies',
+        'repository', 'documentation',
+        'homepage', 'issues',
+
+        # files meta:
+        FileMetaKeysType,
+    ]
+    ManifestValueType = Dict[
+        CollectionInfoKeysType,
+        Optional[
+            Union[
+                int, str,  # scalars, like name/ns, schema version
+                List[str],  # lists of scalars, like tags
+                Dict[str, str],  # deps map
+            ],
+        ],
+    ]
+    CollectionManifestType = Dict[ManifestKeysType, ManifestValueType]
+    FileManifestEntryType = Dict[FileMetaKeysType, Optional[Union[str, int]]]
+    FilesManifestType = Dict[
+        Literal['files', 'format'],
+        Union[List[FileManifestEntryType], int],
+    ]
 
 import ansible.constants as C
 from ansible.errors import AnsibleError
 from ansible.galaxy import get_collections_galaxy_meta_info
-from ansible.galaxy.api import CollectionVersionMetadata, GalaxyError
-from ansible.galaxy.user_agent import user_agent
-from ansible.module_utils import six
+from ansible.galaxy.collection.concrete_artifact_manager import (
+    _consume_file,
+    _download_file,
+    _get_meta_from_src_dir,
+    _tarfile_extract,
+)
+from ansible.galaxy.collection.galaxy_api_proxy import MultiGalaxyAPIProxy
+from ansible.galaxy.dependency_resolution import (
+    build_collection_dependency_resolver,
+)
+from ansible.galaxy.dependency_resolution.dataclasses import (
+    Candidate, Requirement,
+)
+from ansible.galaxy.dependency_resolution.errors import (
+    CollectionDependencyResolutionImpossible,
+)
+from ansible.galaxy.dependency_resolution.versioning import meets_requirements
+from ansible.module_utils.six import raise_from
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.utils.collection_loader import AnsibleCollectionRef
 from ansible.utils.display import Display
-from ansible.utils.galaxy import scm_archive_collection
 from ansible.utils.hashing import secure_hash, secure_hash_s
 from ansible.utils.version import SemanticVersion
-from ansible.module_utils.urls import open_url
-
-urlparse = six.moves.urllib.parse.urlparse
-urldefrag = six.moves.urllib.parse.urldefrag
-urllib_error = six.moves.urllib.error
 
 
 display = Display()
@@ -58,498 +128,87 @@ MANIFEST_FORMAT = 1
 ModifiedContent = namedtuple('ModifiedContent', ['filename', 'expected', 'installed'])
 
 
-class CollectionRequirement:
+def verify_local_collection(
+        local_collection, remote_collection,
+        artifacts_manager,
+):  # type: (Candidate, Candidate, ConcreteArtifactsManager) -> None
+    b_temp_tar_path = (  # NOTE: AnsibleError is raised on URLError
+        artifacts_manager.get_artifact_path
+        if remote_collection.is_concrete_artifact
+        else artifacts_manager.get_galaxy_artifact_path
+    )(remote_collection)
 
-    _FILE_MAPPING = [(b'MANIFEST.json', 'manifest_file'), (b'FILES.json', 'files_file')]
+    b_collection_path = to_bytes(
+        local_collection.src, errors='surrogate_or_strict',
+    )
 
-    def __init__(self, namespace, name, b_path, api, versions, requirement, force, parent=None, metadata=None,
-                 files=None, skip=False, allow_pre_releases=False):
-        """Represents a collection requirement, the versions that are available to be installed as well as any
-        dependencies the collection has.
+    display.vvv("Verifying '{coll!s}'.".format(coll=local_collection))
+    display.vvv(
+        "Installed collection found at '{path!s}'".
+        format(path=to_native(local_collection.src)),
+    )
+    display.vvv(
+        "Remote collection cached as '{path!s}'".
+        format(path=to_native(b_temp_tar_path)),
+    )
 
-        :param namespace: The collection namespace.
-        :param name: The collection name.
-        :param b_path: Byte str of the path to the collection tarball if it has already been downloaded.
-        :param api: The GalaxyAPI to use if the collection is from Galaxy.
-        :param versions: A list of versions of the collection that are available.
-        :param requirement: The version requirement string used to verify the list of versions fit the requirements.
-        :param force: Whether the force flag applied to the collection.
-        :param parent: The name of the parent the collection is a dependency of.
-        :param metadata: The galaxy.api.CollectionVersionMetadata that has already been retrieved from the Galaxy
-            server.
-        :param files: The files that exist inside the collection. This is based on the FILES.json file inside the
-            collection artifact.
-        :param skip: Whether to skip installing the collection. Should be set if the collection is already installed
-            and force is not set.
-        :param allow_pre_releases: Whether to skip pre-release versions of collections.
-        """
-        self.namespace = namespace
-        self.name = name
-        self.b_path = b_path
-        self.api = api
-        self._versions = set(versions)
-        self.force = force
-        self.skip = skip
-        self.required_by = []
-        self.allow_pre_releases = allow_pre_releases
-
-        self._metadata = metadata
-        self._files = files
-
-        self.add_requirement(parent, requirement)
-
-    def __str__(self):
-        return to_native("%s.%s" % (self.namespace, self.name))
-
-    def __unicode__(self):
-        return u"%s.%s" % (self.namespace, self.name)
-
-    @property
-    def metadata(self):
-        self._get_metadata()
-        return self._metadata
-
-    @property
-    def versions(self):
-        if self.allow_pre_releases:
-            return self._versions
-        return set(v for v in self._versions if v == '*' or not SemanticVersion(v).is_prerelease)
-
-    @versions.setter
-    def versions(self, value):
-        self._versions = set(value)
-
-    @property
-    def pre_releases(self):
-        return set(v for v in self._versions if SemanticVersion(v).is_prerelease)
-
-    @property
-    def latest_version(self):
-        try:
-            return max([v for v in self.versions if v != '*'], key=SemanticVersion)
-        except ValueError:  # ValueError: max() arg is an empty sequence
-            return '*'
-
-    @property
-    def dependencies(self):
-        if not self._metadata:
-            if len(self.versions) > 1:
-                return {}
-            self._get_metadata()
-
-        dependencies = self._metadata.dependencies
-
-        if dependencies is None:
-            return {}
-
-        return dependencies
-
-    @staticmethod
-    def artifact_info(b_path):
-        """Load the manifest data from the MANIFEST.json and FILES.json. If the files exist, return a dict containing the keys 'files_file' and 'manifest_file'.
-        :param b_path: The directory of a collection.
-        """
-        info = {}
-        for b_file_name, property_name in CollectionRequirement._FILE_MAPPING:
-            b_file_path = os.path.join(b_path, b_file_name)
-            if not os.path.exists(b_file_path):
-                continue
-            with open(b_file_path, 'rb') as file_obj:
-                try:
-                    info[property_name] = json.loads(to_text(file_obj.read(), errors='surrogate_or_strict'))
-                except ValueError:
-                    raise AnsibleError("Collection file at '%s' does not contain a valid json string." % to_native(b_file_path))
-        return info
-
-    @staticmethod
-    def galaxy_metadata(b_path):
-        """Generate the manifest data from the galaxy.yml file.
-        If the galaxy.yml exists, return a dictionary containing the keys 'files_file' and 'manifest_file'.
-
-        :param b_path: The directory of a collection.
-        """
-        b_galaxy_path = get_galaxy_metadata_path(b_path)
-        info = {}
-        if os.path.exists(b_galaxy_path):
-            collection_meta = _get_galaxy_yml(b_galaxy_path)
-            info['files_file'] = _build_files_manifest(b_path, collection_meta['namespace'], collection_meta['name'], collection_meta['build_ignore'])
-            info['manifest_file'] = _build_manifest(**collection_meta)
-        return info
-
-    @staticmethod
-    def collection_info(b_path, fallback_metadata=False):
-        info = CollectionRequirement.artifact_info(b_path)
-        if info or not fallback_metadata:
-            return info
-        return CollectionRequirement.galaxy_metadata(b_path)
-
-    def add_requirement(self, parent, requirement):
-        self.required_by.append((parent, requirement))
-        new_versions = set(v for v in self.versions if self._meets_requirements(v, requirement, parent))
-        if len(new_versions) == 0:
-            if self.skip:
-                force_flag = '--force-with-deps' if parent else '--force'
-                version = self.latest_version if self.latest_version != '*' else 'unknown'
-                msg = "Cannot meet requirement %s:%s as it is already installed at version '%s'. Use %s to overwrite" \
-                      % (to_text(self), requirement, version, force_flag)
-                raise AnsibleError(msg)
-            elif parent is None:
-                msg = "Cannot meet requirement %s for dependency %s" % (requirement, to_text(self))
-            else:
-                msg = "Cannot meet dependency requirement '%s:%s' for collection %s" \
-                      % (to_text(self), requirement, parent)
-
-            collection_source = to_text(self.b_path, nonstring='passthru') or self.api.api_server
-            req_by = "\n".join(
-                "\t%s - '%s:%s'" % (to_text(p) if p else 'base', to_text(self), r)
-                for p, r in self.required_by
+    # Compare installed version versus requirement version
+    if local_collection.ver != remote_collection.ver:
+        err = (
+            "{local_fqcn!s} has the version '{local_ver!s}' but "
+            "is being compared to '{remote_ver!s}'".format(
+                local_fqcn=local_collection.fqcn,
+                local_ver=local_collection.ver,
+                remote_ver=remote_collection.ver,
             )
-
-            versions = ", ".join(sorted(self.versions, key=SemanticVersion))
-            if not self.versions and self.pre_releases:
-                pre_release_msg = (
-                    '\nThis collection only contains pre-releases. Utilize `--pre` to install pre-releases, or '
-                    'explicitly provide the pre-release version.'
-                )
-            else:
-                pre_release_msg = ''
-
-            raise AnsibleError(
-                "%s from source '%s'. Available versions before last requirement added: %s\nRequirements from:\n%s%s"
-                % (msg, collection_source, versions, req_by, pre_release_msg)
-            )
-
-        self.versions = new_versions
-
-    def download(self, b_path):
-        download_url = self._metadata.download_url
-        artifact_hash = self._metadata.artifact_sha256
-        headers = {}
-        self.api._add_auth_token(headers, download_url, required=False)
-
-        b_collection_path = _download_file(download_url, b_path, artifact_hash, self.api.validate_certs,
-                                           headers=headers)
-
-        return to_text(b_collection_path, errors='surrogate_or_strict')
-
-    def install(self, path, b_temp_path):
-        if self.skip:
-            display.display("Skipping '%s' as it is already installed" % to_text(self))
-            return
-
-        # Install if it is not
-        collection_path = os.path.join(path, self.namespace, self.name)
-        b_collection_path = to_bytes(collection_path, errors='surrogate_or_strict')
-        display.display("Installing '%s:%s' to '%s'" % (to_text(self), self.latest_version, collection_path))
-
-        if self.b_path is None:
-            self.b_path = self.download(b_temp_path)
-
-        if os.path.exists(b_collection_path):
-            shutil.rmtree(b_collection_path)
-
-        if os.path.isfile(self.b_path):
-            self.install_artifact(b_collection_path, b_temp_path)
-        else:
-            self.install_scm(b_collection_path)
-
-        display.display("%s (%s) was installed successfully" % (to_text(self), self.latest_version))
-
-    def install_artifact(self, b_collection_path, b_temp_path):
-
-        try:
-            with tarfile.open(self.b_path, mode='r') as collection_tar:
-                files_member_obj = collection_tar.getmember('FILES.json')
-                with _tarfile_extract(collection_tar, files_member_obj) as (dummy, files_obj):
-                    files = json.loads(to_text(files_obj.read(), errors='surrogate_or_strict'))
-
-                _extract_tar_file(collection_tar, 'MANIFEST.json', b_collection_path, b_temp_path)
-                _extract_tar_file(collection_tar, 'FILES.json', b_collection_path, b_temp_path)
-
-                for file_info in files['files']:
-                    file_name = file_info['name']
-                    if file_name == '.':
-                        continue
-
-                    if file_info['ftype'] == 'file':
-                        _extract_tar_file(collection_tar, file_name, b_collection_path, b_temp_path,
-                                          expected_hash=file_info['chksum_sha256'])
-
-                    else:
-                        _extract_tar_dir(collection_tar, file_name, b_collection_path)
-
-        except Exception:
-            # Ensure we don't leave the dir behind in case of a failure.
-            shutil.rmtree(b_collection_path)
-
-            b_namespace_path = os.path.dirname(b_collection_path)
-            if not os.listdir(b_namespace_path):
-                os.rmdir(b_namespace_path)
-
-            raise
-
-    def install_scm(self, b_collection_output_path):
-        """Install the collection from source control into given dir.
-
-        Generates the Ansible collection artifact data from a galaxy.yml and installs the artifact to a directory.
-        This should follow the same pattern as build_collection, but instead of creating an artifact, install it.
-        :param b_collection_output_path: The installation directory for the collection artifact.
-        :raises AnsibleError: If no collection metadata found.
-        """
-        b_collection_path = self.b_path
-
-        b_galaxy_path = get_galaxy_metadata_path(b_collection_path)
-        if not os.path.exists(b_galaxy_path):
-            raise AnsibleError("The collection galaxy.yml path '%s' does not exist." % to_native(b_galaxy_path))
-
-        info = CollectionRequirement.galaxy_metadata(b_collection_path)
-
-        collection_manifest = info['manifest_file']
-        collection_meta = collection_manifest['collection_info']
-        file_manifest = info['files_file']
-
-        _build_collection_dir(b_collection_path, b_collection_output_path, collection_manifest, file_manifest)
-
-        collection_name = "%s.%s" % (collection_manifest['collection_info']['namespace'],
-                                     collection_manifest['collection_info']['name'])
-        display.display('Created collection for %s at %s' % (collection_name, to_text(b_collection_output_path)))
-
-    def set_latest_version(self):
-        self.versions = set([self.latest_version])
-        self._get_metadata()
-
-    def verify(self, remote_collection, path, b_temp_tar_path):
-        if not self.skip:
-            display.display("'%s' has not been installed, nothing to verify" % (to_text(self)))
-            return
-
-        collection_path = os.path.join(path, self.namespace, self.name)
-        b_collection_path = to_bytes(collection_path, errors='surrogate_or_strict')
-
-        display.vvv("Verifying '%s:%s'." % (to_text(self), self.latest_version))
-        display.vvv("Installed collection found at '%s'" % collection_path)
-        display.vvv("Remote collection found at '%s'" % remote_collection.metadata.download_url)
-
-        # Compare installed version versus requirement version
-        if self.latest_version != remote_collection.latest_version:
-            err = "%s has the version '%s' but is being compared to '%s'" % (to_text(self), self.latest_version, remote_collection.latest_version)
-            display.display(err)
-            return
-
-        modified_content = []
-
-        # Verify the manifest hash matches before verifying the file manifest
-        expected_hash = _get_tar_file_hash(b_temp_tar_path, 'MANIFEST.json')
-        self._verify_file_hash(b_collection_path, 'MANIFEST.json', expected_hash, modified_content)
-        manifest = _get_json_from_tar_file(b_temp_tar_path, 'MANIFEST.json')
-
-        # Use the manifest to verify the file manifest checksum
-        file_manifest_data = manifest['file_manifest_file']
-        file_manifest_filename = file_manifest_data['name']
-        expected_hash = file_manifest_data['chksum_%s' % file_manifest_data['chksum_type']]
-
-        # Verify the file manifest before using it to verify individual files
-        self._verify_file_hash(b_collection_path, file_manifest_filename, expected_hash, modified_content)
-        file_manifest = _get_json_from_tar_file(b_temp_tar_path, file_manifest_filename)
-
-        # Use the file manifest to verify individual file checksums
-        for manifest_data in file_manifest['files']:
-            if manifest_data['ftype'] == 'file':
-                expected_hash = manifest_data['chksum_%s' % manifest_data['chksum_type']]
-                self._verify_file_hash(b_collection_path, manifest_data['name'], expected_hash, modified_content)
-
-        if modified_content:
-            display.display("Collection %s contains modified content in the following files:" % to_text(self))
-            display.display(to_text(self))
-            display.vvv(to_text(self.b_path))
-            for content_change in modified_content:
-                display.display('    %s' % content_change.filename)
-                display.vvv("    Expected: %s\n    Found: %s" % (content_change.expected, content_change.installed))
-        else:
-            display.vvv("Successfully verified that checksums for '%s:%s' match the remote collection" % (to_text(self), self.latest_version))
-
-    def _verify_file_hash(self, b_path, filename, expected_hash, error_queue):
-        b_file_path = to_bytes(os.path.join(to_text(b_path), filename), errors='surrogate_or_strict')
-
-        if not os.path.isfile(b_file_path):
-            actual_hash = None
-        else:
-            with open(b_file_path, mode='rb') as file_object:
-                actual_hash = _consume_file(file_object)
-
-        if expected_hash != actual_hash:
-            error_queue.append(ModifiedContent(filename=filename, expected=expected_hash, installed=actual_hash))
-
-    def _get_metadata(self):
-        if self._metadata:
-            return
-        self._metadata = self.api.get_collection_version_metadata(self.namespace, self.name, self.latest_version)
-
-    def _meets_requirements(self, version, requirements, parent):
-        """
-        Supports version identifiers can be '==', '!=', '>', '>=', '<', '<=', '*'. Each requirement is delimited by ','
-        """
-        op_map = {
-            '!=': operator.ne,
-            '==': operator.eq,
-            '=': operator.eq,
-            '>=': operator.ge,
-            '>': operator.gt,
-            '<=': operator.le,
-            '<': operator.lt,
-        }
-
-        for req in list(requirements.split(',')):
-            op_pos = 2 if len(req) > 1 and req[1] == '=' else 1
-            op = op_map.get(req[:op_pos])
-
-            requirement = req[op_pos:]
-            if not op:
-                requirement = req
-                op = operator.eq
-
-            # In the case we are checking a new requirement on a base requirement (parent != None) we can't accept
-            # version as '*' (unknown version) unless the requirement is also '*'.
-            if parent and version == '*' and requirement != '*':
-                display.warning("Failed to validate the collection requirement '%s:%s' for %s when the existing "
-                                "install does not have a version set, the collection may not work."
-                                % (to_text(self), req, parent))
-                continue
-            elif requirement == '*' or version == '*':
-                continue
-
-            if not op(SemanticVersion(version), SemanticVersion.from_loose_version(LooseVersion(requirement))):
-                break
-        else:
-            return True
-
-        # The loop was broken early, it does not meet all the requirements
-        return False
-
-    @staticmethod
-    def from_tar(b_path, force, parent=None):
-        if not tarfile.is_tarfile(b_path):
-            raise AnsibleError("Collection artifact at '%s' is not a valid tar file." % to_native(b_path))
-
-        info = {}
-        with tarfile.open(b_path, mode='r') as collection_tar:
-            for b_member_name, property_name in CollectionRequirement._FILE_MAPPING:
-                n_member_name = to_native(b_member_name)
-                try:
-                    member = collection_tar.getmember(n_member_name)
-                except KeyError:
-                    raise AnsibleError("Collection at '%s' does not contain the required file %s."
-                                       % (to_native(b_path), n_member_name))
-
-                with _tarfile_extract(collection_tar, member) as (dummy, member_obj):
-                    try:
-                        info[property_name] = json.loads(to_text(member_obj.read(), errors='surrogate_or_strict'))
-                    except ValueError:
-                        raise AnsibleError("Collection tar file member %s does not contain a valid json string."
-                                           % n_member_name)
-
-        meta = info['manifest_file']['collection_info']
-        files = info['files_file']['files']
-
-        namespace = meta['namespace']
-        name = meta['name']
-        version = meta['version']
-        meta = CollectionVersionMetadata(namespace, name, version, None, None, meta['dependencies'])
-
-        if SemanticVersion(version).is_prerelease:
-            allow_pre_release = True
-        else:
-            allow_pre_release = False
-
-        return CollectionRequirement(namespace, name, b_path, None, [version], version, force, parent=parent,
-                                     metadata=meta, files=files, allow_pre_releases=allow_pre_release)
-
-    @staticmethod
-    def from_path(b_path, force, parent=None, fallback_metadata=False, skip=True):
-        info = CollectionRequirement.collection_info(b_path, fallback_metadata)
-
-        allow_pre_release = False
-        if 'manifest_file' in info:
-            manifest = info['manifest_file']['collection_info']
-            namespace = manifest['namespace']
-            name = manifest['name']
-            version = to_text(manifest['version'], errors='surrogate_or_strict')
-
-            try:
-                _v = SemanticVersion()
-                _v.parse(version)
-                if _v.is_prerelease:
-                    allow_pre_release = True
-            except ValueError:
-                display.warning("Collection at '%s' does not have a valid version set, falling back to '*'. Found "
-                                "version: '%s'" % (to_text(b_path), version))
-                version = '*'
-
-            dependencies = manifest['dependencies']
-        else:
-            if fallback_metadata:
-                warning = "Collection at '%s' does not have a galaxy.yml or a MANIFEST.json file, cannot detect version."
-            else:
-                warning = "Collection at '%s' does not have a MANIFEST.json file, cannot detect version."
-            display.warning(warning % to_text(b_path))
-            parent_dir, name = os.path.split(to_text(b_path, errors='surrogate_or_strict'))
-            namespace = os.path.split(parent_dir)[1]
-
-            version = '*'
-            dependencies = {}
-
-        meta = CollectionVersionMetadata(namespace, name, version, None, None, dependencies)
-
-        files = info.get('files_file', {}).get('files', {})
-
-        return CollectionRequirement(namespace, name, b_path, None, [version], version, force, parent=parent,
-                                     metadata=meta, files=files, skip=skip, allow_pre_releases=allow_pre_release)
-
-    @staticmethod
-    def from_name(collection, apis, requirement, force, parent=None, allow_pre_release=False):
-        namespace, name = collection.split('.', 1)
-        galaxy_meta = None
-
-        for api in apis:
-            try:
-                if not (requirement == '*' or requirement.startswith('<') or requirement.startswith('>') or
-                        requirement.startswith('!=')):
-                    # Exact requirement
-                    allow_pre_release = True
-
-                    if requirement.startswith('='):
-                        requirement = requirement.lstrip('=')
-
-                    resp = api.get_collection_version_metadata(namespace, name, requirement)
-
-                    galaxy_meta = resp
-                    versions = [resp.version]
-                else:
-                    versions = api.get_collection_versions(namespace, name)
-            except GalaxyError as err:
-                if err.http_code != 404:
-                    raise
-
-                versions = []
-
-            # Automation Hub doesn't return a 404 but an empty version list so we check that to align both AH and
-            # Galaxy when the collection is not available on that server.
-            if not versions:
-                display.vvv("Collection '%s' is not available from server %s %s" % (collection, api.name,
-                                                                                    api.api_server))
-                continue
-
-            display.vvv("Collection '%s' obtained from server %s %s" % (collection, api.name, api.api_server))
-            break
-        else:
-            raise AnsibleError("Failed to find collection %s:%s" % (collection, requirement))
-
-        req = CollectionRequirement(namespace, name, None, api, versions, requirement, force, parent=parent,
-                                    metadata=galaxy_meta, allow_pre_releases=allow_pre_release)
-        return req
+        )
+        display.display(err)
+        return
+
+    modified_content = []  # type: List[ModifiedContent]
+
+    # Verify the manifest hash matches before verifying the file manifest
+    expected_hash = _get_tar_file_hash(b_temp_tar_path, 'MANIFEST.json')
+    _verify_file_hash(b_collection_path, 'MANIFEST.json', expected_hash, modified_content)
+    manifest = _get_json_from_tar_file(b_temp_tar_path, 'MANIFEST.json')
+
+    # Use the manifest to verify the file manifest checksum
+    file_manifest_data = manifest['file_manifest_file']
+    file_manifest_filename = file_manifest_data['name']
+    expected_hash = file_manifest_data['chksum_%s' % file_manifest_data['chksum_type']]
+
+    # Verify the file manifest before using it to verify individual files
+    _verify_file_hash(b_collection_path, file_manifest_filename, expected_hash, modified_content)
+    file_manifest = _get_json_from_tar_file(b_temp_tar_path, file_manifest_filename)
+
+    # Use the file manifest to verify individual file checksums
+    for manifest_data in file_manifest['files']:
+        if manifest_data['ftype'] == 'file':
+            expected_hash = manifest_data['chksum_%s' % manifest_data['chksum_type']]
+            _verify_file_hash(b_collection_path, manifest_data['name'], expected_hash, modified_content)
+
+    if modified_content:
+        display.display(
+            'Collection {fqcn!s} contains modified content '
+            'in the following files:'.
+            format(fqcn=to_text(local_collection.fqcn)),
+        )
+        display.display(to_text(local_collection.fqcn))
+        display.vvv(to_text(local_collection.src))
+        for content_change in modified_content:
+            display.display('    %s' % content_change.filename)
+            display.vvv("    Expected: %s\n    Found: %s" % (content_change.expected, content_change.installed))
+        # FIXME: Why doesn't this raise a failed return code?
+    else:
+        display.vvv(
+            "Successfully verified that checksums for '{coll!s}' "
+            'match the remote collection'.
+            format(coll=local_collection),
+        )
 
 
 def build_collection(collection_path, output_path, force):
+    # type: (bytes, bytes, bool) -> Text
     """Creates the Ansible collection artifact in a .tar.gz file.
 
     :param collection_path: The path to the collection to build. This should be the directory that contains the
@@ -559,34 +218,49 @@ def build_collection(collection_path, output_path, force):
     :return: The path to the collection build artifact.
     """
     b_collection_path = to_bytes(collection_path, errors='surrogate_or_strict')
-    b_galaxy_path = get_galaxy_metadata_path(b_collection_path)
-    if not os.path.exists(b_galaxy_path):
-        raise AnsibleError("The collection galaxy.yml path '%s' does not exist." % to_native(b_galaxy_path))
+    try:
+        collection_meta = _get_meta_from_src_dir(b_collection_path)
+    except LookupError as lookup_err:
+        raise_from(AnsibleError(to_native(lookup_err)), lookup_err)
 
-    info = CollectionRequirement.galaxy_metadata(b_collection_path)
+    collection_manifest = _build_manifest(**collection_meta)
+    file_manifest = _build_files_manifest(
+        b_collection_path,
+        collection_meta['namespace'],  # type: ignore
+        collection_meta['name'],  # type: ignore
+        collection_meta['build_ignore'],  # type: ignore
+    )
 
-    collection_manifest = info['manifest_file']
-    collection_meta = collection_manifest['collection_info']
-    file_manifest = info['files_file']
+    artifact_tarball_file_name = '{ns!s}-{name!s}-{ver!s}.tar.gz'.format(
+        name=collection_meta['name'],
+        ns=collection_meta['namespace'],
+        ver=collection_meta['version'],
+    )
+    b_collection_output = os.path.join(
+        output_path,
+        to_bytes(artifact_tarball_file_name, errors='surrogate_or_strict'),
+    )
 
-    collection_output = os.path.join(output_path, "%s-%s-%s.tar.gz" % (collection_meta['namespace'],
-                                                                       collection_meta['name'],
-                                                                       collection_meta['version']))
-
-    b_collection_output = to_bytes(collection_output, errors='surrogate_or_strict')
     if os.path.exists(b_collection_output):
         if os.path.isdir(b_collection_output):
             raise AnsibleError("The output collection artifact '%s' already exists, "
-                               "but is a directory - aborting" % to_native(collection_output))
+                               "but is a directory - aborting" % to_native(b_collection_output))
         elif not force:
             raise AnsibleError("The file '%s' already exists. You can use --force to re-create "
-                               "the collection artifact." % to_native(collection_output))
+                               "the collection artifact." % to_native(b_collection_output))
 
-    _build_collection_tar(b_collection_path, b_collection_output, collection_manifest, file_manifest)
+    collection_output = _build_collection_tar(b_collection_path, b_collection_output, collection_manifest, file_manifest)
     return collection_output
 
 
-def download_collections(collections, output_path, apis, validate_certs, no_deps, allow_pre_release):
+def download_collections(
+        collections,  # type: Iterable[Requirement]
+        output_path,  # type: str
+        apis,  # type: Iterable[GalaxyAPI]
+        no_deps,  # type: bool
+        allow_pre_release,  # type: bool
+        artifacts_manager,  # type: ConcreteArtifactsManager
+):  # type: (...) -> None
     """Download Ansible collections as their tarball from a Galaxy server to the path specified and creates a requirements
     file of the downloaded requirements to be used for an install.
 
@@ -597,41 +271,85 @@ def download_collections(collections, output_path, apis, validate_certs, no_deps
     :param no_deps: Ignore any collection dependencies and only download the base requirements.
     :param allow_pre_release: Do not ignore pre-release versions when selecting the latest.
     """
-    with _tempdir() as b_temp_path:
-        with _display_progress("Process download dependency map"):
-            dep_map = _build_dependency_map(collections, [], b_temp_path, apis, validate_certs, True, True, no_deps,
-                                            allow_pre_release=allow_pre_release)
+    with _display_progress("Process download dependency map"):
+        dep_map = _resolve_depenency_map(
+            set(collections),
+            galaxy_apis=apis,
+            concrete_artifacts_manager=artifacts_manager,
+            no_deps=no_deps,
+            allow_pre_release=allow_pre_release,
+        )
 
-        requirements = []
-        with _display_progress(
-                "Starting collection download process to '{path!s}'".
-                format(path=output_path),
-        ):
-            for name, requirement in dep_map.items():
-                collection_filename = "%s-%s-%s.tar.gz" % (requirement.namespace, requirement.name,
-                                                           requirement.latest_version)
-                dest_path = os.path.join(output_path, collection_filename)
-                requirements.append({'name': collection_filename, 'version': requirement.latest_version})
+    b_output_path = to_bytes(output_path, errors='surrogate_or_strict')
 
-                display.display("Downloading collection '%s' to '%s'" % (name, dest_path))
+    requirements = []
+    with _display_progress(
+            "Starting collection download process to '{path!s}'".
+            format(path=output_path),
+    ):
+        for fqcn, concrete_coll_pin in dep_map.copy().items():  # FIXME: move into the provider
+            if concrete_coll_pin.is_virtual:
+                display.v(
+                    'Virtual collection {coll!s} is not downloadable'.
+                    format(coll=to_text(concrete_coll_pin)),
+                )
+                continue
 
-                if requirement.api is None and requirement.b_path and os.path.isfile(requirement.b_path):
-                    shutil.copy(requirement.b_path, to_bytes(dest_path, errors='surrogate_or_strict'))
-                elif requirement.api is None and requirement.b_path:
-                    temp_path = to_text(b_temp_path, errors='surrogate_or_string')
-                    temp_download_path = build_collection(requirement.b_path, temp_path, True)
-                    shutil.move(to_bytes(temp_download_path, errors='surrogate_or_strict'),
-                                to_bytes(dest_path, errors='surrogate_or_strict'))
-                else:
-                    b_temp_download_path = requirement.download(b_temp_path)
-                    shutil.move(b_temp_download_path, to_bytes(dest_path, errors='surrogate_or_strict'))
+            display.display(
+                "Downloading collection '{coll!s}' to '{path!s}'".
+                format(coll=concrete_coll_pin, path=to_native(b_output_path)),
+            )
 
-                display.display("%s (%s) was downloaded successfully" % (name, requirement.latest_version))
+            b_src_path = (
+                artifacts_manager.get_artifact_path
+                if concrete_coll_pin.is_concrete_artifact
+                else artifacts_manager.get_galaxy_artifact_path
+            )(concrete_coll_pin)
 
-            requirements_path = os.path.join(output_path, 'requirements.yml')
-            display.display("Writing requirements.yml file of downloaded collections to '%s'" % requirements_path)
-            with open(to_bytes(requirements_path, errors='surrogate_or_strict'), mode='wb') as req_fd:
-                req_fd.write(to_bytes(yaml.safe_dump({'collections': requirements}), errors='surrogate_or_strict'))
+            b_dest_path = os.path.join(
+                to_bytes(output_path, errors='surrogate_or_strict'),
+                os.path.basename(b_src_path),
+            )
+
+            if concrete_coll_pin.is_dir:
+                b_dest_path = to_bytes(
+                    build_collection(
+                        b_src_path, b_output_path, force=True,
+                    ),
+                    errors='surrogate_or_strict',
+                )
+            else:
+                shutil.copy(to_native(b_src_path), to_native(b_dest_path))
+
+            display.display(
+                "Collection '{coll!s}' was downloaded successfully".
+                format(coll=concrete_coll_pin),
+            )
+            requirements.append({
+                # FIXME: Consider using a more specific upgraded format
+                # FIXME: having FQCN in the name field, with src field
+                # FIXME: pointing to the file path, and explicitly set
+                # FIXME: type. If version and name are set, it'd
+                # FIXME: perform validation against the actual metadata
+                # FIXME: in the artifact src points at.
+                'name': to_native(os.path.basename(b_dest_path)),
+                'version': concrete_coll_pin.ver,
+            })
+
+        requirements_path = os.path.join(output_path, 'requirements.yml')
+        b_requirements_path = to_bytes(
+            requirements_path, errors='surrogate_or_strict',
+        )
+        display.display(
+            'Writing requirements.yml file of downloaded collections '
+            "to '{path!s}'".format(path=requirements_path),
+        )
+        yaml_bytes = to_bytes(
+            yaml.safe_dump({'collections': requirements}),
+            errors='surrogate_or_strict',
+        )
+        with open(b_requirements_path, mode='wb') as req_fd:
+            req_fd.write(yaml_bytes)
 
 
 def publish_collection(collection_path, api, wait, timeout):
@@ -671,8 +389,17 @@ def publish_collection(collection_path, api, wait, timeout):
                         % (api.name, api.api_server, import_uri))
 
 
-def install_collections(collections, output_path, apis, validate_certs, ignore_errors, no_deps, force, force_deps,
-                        allow_pre_release=False):
+def install_collections(
+        collections,  # type: Iterable[Requirement]
+        output_path,  # type: str
+        apis,  # type: Iterable[GalaxyAPI]
+        ignore_errors,  # type: bool
+        no_deps,  # type: bool
+        force,  # type: bool
+        force_deps,  # type: bool
+        allow_pre_release,  # type: bool
+        artifacts_manager,  # type: ConcreteArtifactsManager
+):  # type: (...) -> None
     """Install Ansible collections to the path specified.
 
     :param collections: The collections to install, should be a list of tuples with (name, requirement, Galaxy server).
@@ -684,27 +411,121 @@ def install_collections(collections, output_path, apis, validate_certs, ignore_e
     :param force: Re-install a collection if it has already been installed.
     :param force_deps: Re-install a collection as well as its dependencies if they have already been installed.
     """
-    existing_collections = find_existing_collections(output_path, fallback_metadata=True)
+    existing_collections = {
+        Requirement(coll.fqcn, coll.ver, coll.src, coll.type)
+        for coll in find_existing_collections(output_path, artifacts_manager)
+    }
 
-    with _tempdir() as b_temp_path:
-        with _display_progress("Process install dependency map"):
-            dependency_map = _build_dependency_map(collections, existing_collections, b_temp_path, apis,
-                                                   validate_certs, force, force_deps, no_deps,
-                                                   allow_pre_release=allow_pre_release)
+    requested_requirements = set(
+        chain.from_iterable(
+            (
+                Requirement.from_dir_path(sub_coll, artifacts_manager)
+                for sub_coll in (
+                    artifacts_manager.
+                    get_direct_collection_dependencies(install_req).
+                    keys()
+                )
+            )
+            if install_req.is_subdirs else (install_req, )
+            for install_req in collections
+        ),
+    )
+    requested_requirements_names = {req.fqcn for req in requested_requirements}
 
-        with _display_progress("Starting collection install process"):
-            for collection in dependency_map.values():
-                try:
-                    collection.install(output_path, b_temp_path)
-                except AnsibleError as err:
-                    if ignore_errors:
-                        display.warning("Failed to install collection %s but skipping due to --ignore-errors being set. "
-                                        "Error: %s" % (to_text(collection), to_text(err)))
-                    else:
-                        raise
+    # NOTE: Don't attempt to reevaluate already installed deps
+    # NOTE: unless `--force` is passed
+    # FIXME: debug why `--force` doesn't always work well
+    requested_requirements -= set() if force else {
+        req
+        for req in requested_requirements
+        for exs in existing_collections
+        if req.fqcn == exs.fqcn and meets_requirements(exs.ver, req.ver)
+    }
+
+    # FIXME: This probably needs to be improved to
+    # FIXME: properly match differing src/type.
+    existing_non_requested_collections = {
+        coll for coll in existing_collections
+        if coll.fqcn not in requested_requirements_names
+    }
+    # NOTE: Pin installed collection versions that are
+    # NOTE: not directly requested via CLI if `--force-deps` is not set
+    requested_requirements |= (
+        set() if force_deps
+        else existing_non_requested_collections
+    )
+
+    if not requested_requirements:
+        display.display(
+            'Nothing to do. All requested collections are already '
+            'installed. If you want to reinstall them, '
+            'consider using `--force`.'
+        )
+        return
+
+    with _display_progress("Process install dependency map"):
+        # FIXME: Attempt to resolve deps with installed collections
+        # FIXME: pinned and if that results in conflicts, rerun without
+        # FIXME: those pre-installed collection deps pinned.
+        dependency_map = _resolve_depenency_map(
+            requested_requirements,
+            galaxy_apis=apis,
+            concrete_artifacts_manager=artifacts_manager,
+            no_deps=no_deps,
+            allow_pre_release=allow_pre_release,
+        )
+
+    with _display_progress("Starting collection install process"):
+        for fqcn, concrete_coll_pin in dependency_map.items():
+            if concrete_coll_pin.is_virtual:
+                display.vvvv(
+                    "Skipping '{coll!s}' as it is virtual".
+                    format(coll=to_text(concrete_coll_pin)),
+                )
+                continue
+
+            current_requirement = Requirement(
+                fqcn=concrete_coll_pin.fqcn,
+                ver=concrete_coll_pin.ver,
+                src=concrete_coll_pin.src,
+                type=concrete_coll_pin.type,
+            )
+            needs_skipping = (
+                # NOTE: No need to reinstall transitive deps
+                # NOTE: unless `--force-deps` is set
+                not force_deps and
+                current_requirement in existing_non_requested_collections
+
+                # NOTE: No need to reinstall already installed
+                # NOTE: requested targets unless `--force` is set
+                or not force
+                and current_requirement in existing_collections
+            )
+            if needs_skipping:
+                display.display(
+                    "Skipping '{coll!s}' as it is already installed".
+                    format(coll=to_text(concrete_coll_pin)),
+                )
+                continue
+
+            try:
+                install(concrete_coll_pin, output_path, artifacts_manager)
+            except AnsibleError as err:
+                if ignore_errors:
+                    display.warning(
+                        'Failed to install collection {coll!s} but skipping '
+                        'due to --ignore-errors being set. Error: {error!s}'.
+                        format(
+                            coll=to_text(concrete_coll_pin),
+                            error=to_text(err),
+                        )
+                    )
+                else:
+                    raise
 
 
-def validate_collection_name(name):
+# NOTE: imported in ansible.cli.galaxy
+def validate_collection_name(name):  # type: (str) -> str
     """Validates the collection name as an input from the user or a requirements file fit the requirements.
 
     :param name: The input name with optional range specifier split by ':'.
@@ -720,7 +541,8 @@ def validate_collection_name(name):
                        "characters from [a-zA-Z0-9_] only." % name)
 
 
-def validate_collection_path(collection_path):
+# NOTE: imported in ansible.cli.galaxy
+def validate_collection_path(collection_path):  # type: (str) -> str
     """Ensure a given path ends with 'ansible_collections'
 
     :param collection_path: The path that should end in 'ansible_collections'
@@ -733,73 +555,97 @@ def validate_collection_path(collection_path):
     return collection_path
 
 
-def verify_collections(collections, search_paths, apis, validate_certs, ignore_errors, allow_pre_release=False):
+def verify_collections(
+        collections,  # type: Iterable[Requirement]
+        search_paths,  # type: Iterable[str]
+        apis,  # type: Iterable[GalaxyAPI]
+        ignore_errors,  # type: bool
+        allow_pre_release,  # type: bool  # FIXME: is this arg necessary?
+        artifacts_manager,  # type: ConcreteArtifactsManager
+):  # type: (...) -> None
+    api_proxy = MultiGalaxyAPIProxy(apis, artifacts_manager)
 
     with _display_progress():
-        with _tempdir() as b_temp_path:
-            for collection in collections:
+        for collection in collections:
+            try:
+                if collection.is_concrete_artifact:
+                    raise AnsibleError(
+                        message="'{coll_type!s}' type is not supported. "
+                        'The format namespace.name is expected.'.
+                        format(coll_type=collection.type)
+                    )
+
+                # NOTE: Verify local collection exists before
+                # NOTE: downloading its source artifact from
+                # NOTE: a galaxy server.
+                for search_path in search_paths:
+                    b_search_path = to_bytes(
+                        os.path.join(
+                            search_path,
+                            collection.namespace, collection.name,
+                        ),
+                        errors='surrogate_or_strict',
+                    )
+                    if not os.path.isdir(b_search_path):
+                        continue
+
+                    local_collection = Candidate.from_dir_path(
+                        b_search_path, artifacts_manager,
+                    )
+                    break
+                else:
+                    raise AnsibleError(message='Collection %s is not installed in any of the collection paths.' % collection.fqcn)
+
+                remote_collection = Candidate(
+                    collection.fqcn, collection.ver,
+                    None, 'galaxy',
+                )
+
+                # Download collection on a galaxy server for comparison
                 try:
+                    # NOTE: Trigger the lookup. If found, it'll cache
+                    # NOTE: download URL and token in artifact manager.
+                    api_proxy.get_collection_version_metadata(
+                        remote_collection,
+                    )
+                except AnsibleError as e:  # FIXME: does this actually emit any errors?
+                    # FIXME: extract the actual message and adjust this:
+                    expected_error_msg = (
+                        'Failed to find collection {coll.fqcn!s}:{coll.ver!s}'.
+                        format(coll=collection)
+                    )
+                    if e.message == expected_error_msg:
+                        raise AnsibleError(
+                            'Failed to find remote collection '
+                            "'{coll!s}' on any of the galaxy servers".
+                            format(coll=collection)
+                        )
+                    raise
 
-                    local_collection = None
-                    b_collection = to_bytes(collection[0], errors='surrogate_or_strict')
+                verify_local_collection(
+                    local_collection, remote_collection,
+                    artifacts_manager,
+                )
 
-                    if os.path.isfile(b_collection) or urlparse(collection[0]).scheme.lower() in ['http', 'https'] or len(collection[0].split('.')) != 2:
-                        raise AnsibleError(message="'%s' is not a valid collection name. The format namespace.name is expected." % collection[0])
-
-                    collection_name = collection[0]
-                    namespace, name = collection_name.split('.')
-                    collection_version = collection[1]
-
-                    # Verify local collection exists before downloading it from a galaxy server
-                    for search_path in search_paths:
-                        b_search_path = to_bytes(os.path.join(search_path, namespace, name), errors='surrogate_or_strict')
-                        if os.path.isdir(b_search_path):
-                            if not os.path.isfile(os.path.join(to_text(b_search_path, errors='surrogate_or_strict'), 'MANIFEST.json')):
-                                raise AnsibleError(
-                                    message="Collection %s does not appear to have a MANIFEST.json. " % collection_name +
-                                            "A MANIFEST.json is expected if the collection has been built and installed via ansible-galaxy."
-                                )
-                            local_collection = CollectionRequirement.from_path(b_search_path, False)
-                            break
-                    if local_collection is None:
-                        raise AnsibleError(message='Collection %s is not installed in any of the collection paths.' % collection_name)
-
-                    # Download collection on a galaxy server for comparison
-                    try:
-                        remote_collection = CollectionRequirement.from_name(collection_name, apis, collection_version, False, parent=None,
-                                                                            allow_pre_release=allow_pre_release)
-                    except AnsibleError as e:
-                        if e.message == 'Failed to find collection %s:%s' % (collection[0], collection[1]):
-                            raise AnsibleError('Failed to find remote collection %s:%s on any of the galaxy servers' % (collection[0], collection[1]))
-                        raise
-
-                    download_url = remote_collection.metadata.download_url
-                    headers = {}
-                    remote_collection.api._add_auth_token(headers, download_url, required=False)
-                    b_temp_tar_path = _download_file(download_url, b_temp_path, None, validate_certs, headers=headers)
-
-                    local_collection.verify(remote_collection, search_path, b_temp_tar_path)
-
-                except AnsibleError as err:
-                    if ignore_errors:
-                        display.warning("Failed to verify collection %s but skipping due to --ignore-errors being set. "
-                                        "Error: %s" % (collection[0], to_text(err)))
-                    else:
-                        raise
+            except AnsibleError as err:
+                if ignore_errors:
+                    display.warning(
+                        "Failed to verify collection '{coll!s}' but skipping "
+                        'due to --ignore-errors being set. '
+                        'Error: {err!s}'.
+                        format(coll=collection, err=to_text(err)),
+                    )
+                else:
+                    raise
 
 
 @contextmanager
 def _tempdir():
     b_temp_path = tempfile.mkdtemp(dir=to_bytes(C.DEFAULT_LOCAL_TMP, errors='surrogate_or_strict'))
-    yield b_temp_path
-    shutil.rmtree(b_temp_path)
-
-
-@contextmanager
-def _tarfile_extract(tar, member):
-    tar_obj = tar.extractfile(member)
-    yield member, tar_obj
-    tar_obj.close()
+    try:
+        yield b_temp_path
+    finally:
+        shutil.rmtree(b_temp_path)
 
 
 @contextmanager
@@ -870,70 +716,21 @@ def _display_progress(msg=None):
         display = old_display
 
 
-def _get_galaxy_yml(b_galaxy_yml_path):
-    meta_info = get_collections_galaxy_meta_info()
+def _verify_file_hash(b_path, filename, expected_hash, error_queue):
+    b_file_path = to_bytes(os.path.join(to_text(b_path), filename), errors='surrogate_or_strict')
 
-    mandatory_keys = set()
-    string_keys = set()
-    list_keys = set()
-    dict_keys = set()
+    if not os.path.isfile(b_file_path):
+        actual_hash = None
+    else:
+        with open(b_file_path, mode='rb') as file_object:
+            actual_hash = _consume_file(file_object)
 
-    for info in meta_info:
-        if info.get('required', False):
-            mandatory_keys.add(info['key'])
-
-        key_list_type = {
-            'str': string_keys,
-            'list': list_keys,
-            'dict': dict_keys,
-        }[info.get('type', 'str')]
-        key_list_type.add(info['key'])
-
-    all_keys = frozenset(list(mandatory_keys) + list(string_keys) + list(list_keys) + list(dict_keys))
-
-    try:
-        with open(b_galaxy_yml_path, 'rb') as g_yaml:
-            galaxy_yml = yaml.safe_load(g_yaml)
-    except YAMLError as err:
-        raise AnsibleError("Failed to parse the galaxy.yml at '%s' with the following error:\n%s"
-                           % (to_native(b_galaxy_yml_path), to_native(err)))
-
-    set_keys = set(galaxy_yml.keys())
-    missing_keys = mandatory_keys.difference(set_keys)
-    if missing_keys:
-        raise AnsibleError("The collection galaxy.yml at '%s' is missing the following mandatory keys: %s"
-                           % (to_native(b_galaxy_yml_path), ", ".join(sorted(missing_keys))))
-
-    extra_keys = set_keys.difference(all_keys)
-    if len(extra_keys) > 0:
-        display.warning("Found unknown keys in collection galaxy.yml at '%s': %s"
-                        % (to_text(b_galaxy_yml_path), ", ".join(extra_keys)))
-
-    # Add the defaults if they have not been set
-    for optional_string in string_keys:
-        if optional_string not in galaxy_yml:
-            galaxy_yml[optional_string] = None
-
-    for optional_list in list_keys:
-        list_val = galaxy_yml.get(optional_list, None)
-
-        if list_val is None:
-            galaxy_yml[optional_list] = []
-        elif not isinstance(list_val, list):
-            galaxy_yml[optional_list] = [list_val]
-
-    for optional_dict in dict_keys:
-        if optional_dict not in galaxy_yml:
-            galaxy_yml[optional_dict] = {}
-
-    # license is a builtin var in Python, to avoid confusion we just rename it to license_ids
-    galaxy_yml['license_ids'] = galaxy_yml['license']
-    del galaxy_yml['license']
-
-    return galaxy_yml
+    if expected_hash != actual_hash:
+        error_queue.append(ModifiedContent(filename=filename, expected=expected_hash, installed=actual_hash))
 
 
 def _build_files_manifest(b_collection_path, namespace, name, ignore_patterns):
+    # type: (bytes, str, str, List[str]) -> FilesManifestType
     # We always ignore .pyc and .retry files as well as some well known version control directories. The ignore
     # patterns can be extended by the build_ignore key in galaxy.yml
     b_ignore_patterns = [
@@ -966,7 +763,7 @@ def _build_files_manifest(b_collection_path, namespace, name, ignore_patterns):
             },
         ],
         'format': MANIFEST_FORMAT,
-    }
+    }  # type: FilesManifestType
 
     def _walk(b_path, b_top_level_dir):
         for b_item in os.listdir(b_path):
@@ -1017,9 +814,9 @@ def _build_files_manifest(b_collection_path, namespace, name, ignore_patterns):
     return manifest
 
 
-def _build_manifest(namespace, name, version, authors, readme, tags, description, license_ids, license_file,
+# FIXME: accept a dict produced from `galaxy.yml` instead of separate args
+def _build_manifest(namespace, name, version, authors, readme, tags, description, license_file,
                     dependencies, repository, documentation, homepage, issues, **kwargs):
-
     manifest = {
         'collection_info': {
             'namespace': namespace,
@@ -1029,8 +826,8 @@ def _build_manifest(namespace, name, version, authors, readme, tags, description
             'readme': readme,
             'tags': tags,
             'description': description,
-            'license': license_ids,
-            'license_file': license_file if license_file else None,  # Handle galaxy.yml having an empty string (None)
+            'license': kwargs['license'],
+            'license_file': license_file or None,  # Handle galaxy.yml having an empty string (None)
             'dependencies': dependencies,
             'repository': repository,
             'documentation': documentation,
@@ -1050,7 +847,12 @@ def _build_manifest(namespace, name, version, authors, readme, tags, description
     return manifest
 
 
-def _build_collection_tar(b_collection_path, b_tar_path, collection_manifest, file_manifest):
+def _build_collection_tar(
+        b_collection_path,  # type: bytes
+        b_tar_path,  # type: bytes
+        collection_manifest,  # type: CollectionManifestType
+        file_manifest,  # type: FilesManifestType
+):  # type: (...) -> Text
     """Build a tar.gz collection artifact from the manifest data."""
     files_manifest_json = to_bytes(json.dumps(file_manifest, indent=True), errors='surrogate_or_strict')
     collection_manifest['file_manifest_file']['chksum_sha256'] = secure_hash_s(files_manifest_json, hash_func=sha256)
@@ -1065,11 +867,11 @@ def _build_collection_tar(b_collection_path, b_tar_path, collection_manifest, fi
                 b_io = BytesIO(b)
                 tar_info = tarfile.TarInfo(name)
                 tar_info.size = len(b)
-                tar_info.mtime = time.time()
+                tar_info.mtime = int(time.time())
                 tar_info.mode = 0o0644
                 tar_file.addfile(tarinfo=tar_info, fileobj=b_io)
 
-            for file_info in file_manifest['files']:
+            for file_info in file_manifest['files']:  # type: ignore
                 if file_info['name'] == '.':
                     continue
 
@@ -1100,12 +902,19 @@ def _build_collection_tar(b_collection_path, b_tar_path, collection_manifest, fi
                         continue
 
                 # Dealing with a normal file, just add it by name.
-                tar_file.add(os.path.realpath(b_src_path), arcname=filename, recursive=False, filter=reset_stat)
+                tar_file.add(
+                    to_native(os.path.realpath(b_src_path)),
+                    arcname=filename,
+                    recursive=False,
+                    filter=reset_stat,
+                )
 
-        shutil.copy(b_tar_filepath, b_tar_path)
+        shutil.copy(to_native(b_tar_filepath), to_native(b_tar_path))
         collection_name = "%s.%s" % (collection_manifest['collection_info']['namespace'],
                                      collection_manifest['collection_info']['name'])
+        tar_path = to_text(b_tar_path)
         display.display('Created collection for %s at %s' % (collection_name, to_text(b_tar_path)))
+        return tar_path
 
 
 def _build_collection_dir(b_collection_path, b_collection_output, collection_manifest, file_manifest):
@@ -1149,263 +958,127 @@ def _build_collection_dir(b_collection_path, b_collection_output, collection_man
             shutil.copyfile(src_file, dest_file)
 
         os.chmod(dest_file, mode)
+    collection_output = to_text(b_collection_output)
+    return collection_output
 
 
-def find_existing_collections(path, fallback_metadata=False):
-    collections = []
-
+def find_existing_collections(path, artifacts_manager):
     b_path = to_bytes(path, errors='surrogate_or_strict')
+
+    # FIXME: consider using `glob.glob()` to simplify looping
     for b_namespace in os.listdir(b_path):
         b_namespace_path = os.path.join(b_path, b_namespace)
         if os.path.isfile(b_namespace_path):
             continue
 
+        # FIXME: consider feeding b_namespace_path to Candidate.from_dir_path to get subdirs automatically
         for b_collection in os.listdir(b_namespace_path):
             b_collection_path = os.path.join(b_namespace_path, b_collection)
-            if os.path.isdir(b_collection_path):
-                req = CollectionRequirement.from_path(b_collection_path, False, fallback_metadata=fallback_metadata)
-                display.vvv("Found installed collection %s:%s at '%s'" % (to_text(req), req.latest_version,
-                                                                          to_text(b_collection_path)))
-                collections.append(req)
+            if not os.path.isdir(b_collection_path):
+                continue
 
-    return collections
-
-
-def _build_dependency_map(collections, existing_collections, b_temp_path, apis, validate_certs, force, force_deps,
-                          no_deps, allow_pre_release=False):
-    dependency_map = {}
-
-    # First build the dependency map on the actual requirements
-    for name, version, source, req_type in collections:
-        _get_collection_info(dependency_map, existing_collections, name, version, source, b_temp_path, apis,
-                             validate_certs, (force or force_deps), allow_pre_release=allow_pre_release, req_type=req_type)
-
-    checked_parents = set([to_text(c) for c in dependency_map.values() if c.skip])
-    while len(dependency_map) != len(checked_parents):
-        while not no_deps:  # Only parse dependencies if no_deps was not set
-            parents_to_check = set(dependency_map.keys()).difference(checked_parents)
-
-            deps_exhausted = True
-            for parent in parents_to_check:
-                parent_info = dependency_map[parent]
-
-                if parent_info.dependencies:
-                    deps_exhausted = False
-                    for dep_name, dep_requirement in parent_info.dependencies.items():
-                        _get_collection_info(dependency_map, existing_collections, dep_name, dep_requirement,
-                                             None, b_temp_path, apis, validate_certs, force_deps,
-                                             parent=parent, allow_pre_release=allow_pre_release)
-
-                    checked_parents.add(parent)
-
-            # No extra dependencies were resolved, exit loop
-            if deps_exhausted:
-                break
-
-        # Now we have resolved the deps to our best extent, now select the latest version for collections with
-        # multiple versions found and go from there
-        deps_not_checked = set(dependency_map.keys()).difference(checked_parents)
-        for collection in deps_not_checked:
-            dependency_map[collection].set_latest_version()
-            if no_deps or len(dependency_map[collection].dependencies) == 0:
-                checked_parents.add(collection)
-
-    return dependency_map
-
-
-def _collections_from_scm(collection, requirement, b_temp_path, force, parent=None):
-    """Returns a list of collections found in the repo. If there is a galaxy.yml in the collection then just return
-    the specific collection. Otherwise, check each top-level directory for a galaxy.yml.
-
-    :param collection: URI to a git repo
-    :param requirement: The version of the artifact
-    :param b_temp_path: The temporary path to the archive of a collection
-    :param force: Whether to overwrite an existing collection or fail
-    :param parent: The name of the parent collection
-    :raises AnsibleError: if nothing found
-    :return: List of CollectionRequirement objects
-    :rtype: list
-    """
-
-    reqs = []
-    name, version, path, fragment = parse_scm(collection, requirement)
-    b_repo_root = to_bytes(name, errors='surrogate_or_strict')
-
-    b_collection_path = os.path.join(b_temp_path, b_repo_root)
-    if fragment:
-        b_fragment = to_bytes(fragment, errors='surrogate_or_strict')
-        b_collection_path = os.path.join(b_collection_path, b_fragment)
-
-    b_galaxy_path = get_galaxy_metadata_path(b_collection_path)
-
-    err = ("%s appears to be an SCM collection source, but the required galaxy.yml was not found. "
-           "Append #path/to/collection/ to your URI (before the comma separated version, if one is specified) "
-           "to point to a directory containing the galaxy.yml or directories of collections" % collection)
-
-    display.vvvvv("Considering %s as a possible path to a collection's galaxy.yml" % b_galaxy_path)
-    if os.path.exists(b_galaxy_path):
-        return [CollectionRequirement.from_path(b_collection_path, force, parent, fallback_metadata=True, skip=False)]
-
-    if not os.path.isdir(b_collection_path) or not os.listdir(b_collection_path):
-        raise AnsibleError(err)
-
-    for b_possible_collection in os.listdir(b_collection_path):
-        b_collection = os.path.join(b_collection_path, b_possible_collection)
-        if not os.path.isdir(b_collection):
-            continue
-        b_galaxy = get_galaxy_metadata_path(b_collection)
-        display.vvvvv("Considering %s as a possible path to a collection's galaxy.yml" % b_galaxy)
-        if os.path.exists(b_galaxy):
-            reqs.append(CollectionRequirement.from_path(b_collection, force, parent, fallback_metadata=True, skip=False))
-    if not reqs:
-        raise AnsibleError(err)
-
-    return reqs
-
-
-def _get_collection_info(dep_map, existing_collections, collection, requirement, source, b_temp_path, apis,
-                         validate_certs, force, parent=None, allow_pre_release=False, req_type=None):
-    dep_msg = ""
-    if parent:
-        dep_msg = " - as dependency of %s" % parent
-    display.vvv("Processing requirement collection '%s'%s" % (to_text(collection), dep_msg))
-
-    b_tar_path = None
-
-    is_file = (
-        req_type == 'file' or
-        (not req_type and os.path.isfile(to_bytes(collection, errors='surrogate_or_strict')))
-    )
-
-    is_url = (
-        req_type == 'url' or
-        (not req_type and urlparse(collection).scheme.lower() in ['http', 'https'])
-    )
-
-    is_scm = (
-        req_type == 'git' or
-        (not req_type and not b_tar_path and collection.startswith(('git+', 'git@')))
-    )
-
-    if is_file:
-        display.vvvv("Collection requirement '%s' is a tar artifact" % to_text(collection))
-        b_tar_path = to_bytes(collection, errors='surrogate_or_strict')
-    elif is_url:
-        display.vvvv("Collection requirement '%s' is a URL to a tar artifact" % collection)
-        try:
-            b_tar_path = _download_file(collection, b_temp_path, None, validate_certs)
-        except urllib_error.URLError as err:
-            raise AnsibleError("Failed to download collection tar from '%s': %s"
-                               % (to_native(collection), to_native(err)))
-
-    if is_scm:
-        if not collection.startswith('git'):
-            collection = 'git+' + collection
-
-        name, version, path, fragment = parse_scm(collection, requirement)
-        b_tar_path = scm_archive_collection(path, name=name, version=version)
-
-        with tarfile.open(b_tar_path, mode='r') as collection_tar:
-            collection_tar.extractall(path=to_text(b_temp_path))
-
-        # Ignore requirement if it is set (it must follow semantic versioning, unlike a git version, which is any tree-ish)
-        # If the requirement was the only place version was set, requirement == version at this point
-        if requirement not in {"*", ""} and requirement != version:
-            display.warning(
-                "The collection {0} appears to be a git repository and two versions were provided: '{1}', and '{2}'. "
-                "The version {2} is being disregarded.".format(collection, version, requirement)
+            req = Candidate.from_dir_path_as_installed(b_collection_path, artifacts_manager)
+            display.vvv(
+                "Found installed collection {coll!s} at '{path!s}'".
+                format(coll=to_text(req), path=to_text(req.src))
             )
-        requirement = "*"
+            yield req
 
-        reqs = _collections_from_scm(collection, requirement, b_temp_path, force, parent)
-        for req in reqs:
-            collection_info = get_collection_info_from_req(dep_map, req)
-            update_dep_map_collection_info(dep_map, existing_collections, collection_info, parent, requirement)
+
+def install(collection, path, artifacts_manager):  # FIXME: mv to dataclasses?
+    # type: (Candidate, str, ConcreteArtifactsManager) -> None
+    assert not collection.is_virtual
+
+    b_artifact_path = (
+        artifacts_manager.get_artifact_path if collection.is_concrete_artifact
+        else artifacts_manager.get_galaxy_artifact_path
+    )(collection)
+
+    collection_path = os.path.join(path, collection.namespace, collection.name)
+    b_collection_path = to_bytes(collection_path, errors='surrogate_or_strict')
+    display.display(
+        "Installing '{coll!s}' to '{path!s}'".
+        format(coll=to_text(collection), path=collection_path),
+    )
+
+    if os.path.exists(b_collection_path):
+        shutil.rmtree(b_collection_path)
+
+    if collection.is_dir:
+        install_src(collection, b_artifact_path, b_collection_path, artifacts_manager)
     else:
-        if b_tar_path:
-            req = CollectionRequirement.from_tar(b_tar_path, force, parent=parent)
-            collection_info = get_collection_info_from_req(dep_map, req)
-        else:
-            validate_collection_name(collection)
+        install_artifact(b_artifact_path, b_collection_path, artifacts_manager._b_working_directory)
 
-            display.vvvv("Collection requirement '%s' is the name of a collection" % collection)
-            if collection in dep_map:
-                collection_info = dep_map[collection]
-                collection_info.add_requirement(parent, requirement)
-            else:
-                apis = [source] if source else apis
-                collection_info = CollectionRequirement.from_name(collection, apis, requirement, force, parent=parent,
-                                                                  allow_pre_release=allow_pre_release)
-
-        update_dep_map_collection_info(dep_map, existing_collections, collection_info, parent, requirement)
+    display.display(
+        '{coll!s} was installed successfully'.
+        format(coll=to_text(collection)),
+    )
 
 
-def get_collection_info_from_req(dep_map, collection):
-    collection_name = to_text(collection)
-    if collection_name in dep_map:
-        collection_info = dep_map[collection_name]
-        collection_info.add_requirement(None, collection.latest_version)
-    else:
-        collection_info = collection
-    return collection_info
+def install_artifact(b_coll_targz_path, b_collection_path, b_temp_path):
+
+    try:
+        with tarfile.open(b_coll_targz_path, mode='r') as collection_tar:
+            files_member_obj = collection_tar.getmember('FILES.json')
+            with _tarfile_extract(collection_tar, files_member_obj) as (dummy, files_obj):
+                files = json.loads(to_text(files_obj.read(), errors='surrogate_or_strict'))
+
+            _extract_tar_file(collection_tar, 'MANIFEST.json', b_collection_path, b_temp_path)
+            _extract_tar_file(collection_tar, 'FILES.json', b_collection_path, b_temp_path)
+
+            for file_info in files['files']:
+                file_name = file_info['name']
+                if file_name == '.':
+                    continue
+
+                if file_info['ftype'] == 'file':
+                    _extract_tar_file(collection_tar, file_name, b_collection_path, b_temp_path,
+                                      expected_hash=file_info['chksum_sha256'])
+
+                else:
+                    _extract_tar_dir(collection_tar, file_name, b_collection_path)
+
+    except Exception:
+        # Ensure we don't leave the dir behind in case of a failure.
+        shutil.rmtree(b_collection_path)
+
+        b_namespace_path = os.path.dirname(b_collection_path)
+        if not os.listdir(b_namespace_path):
+            os.rmdir(b_namespace_path)
+
+        raise
 
 
-def update_dep_map_collection_info(dep_map, existing_collections, collection_info, parent, requirement):
-    existing = [c for c in existing_collections if to_text(c) == to_text(collection_info)]
-    if existing and not collection_info.force:
-        # Test that the installed collection fits the requirement
-        existing[0].add_requirement(parent, requirement)
-        collection_info = existing[0]
+def install_src(
+        collection,
+        b_collection_path, b_collection_output_path,
+        artifacts_manager,
+):
+    """Install the collection from source control into given dir.
 
-    dep_map[to_text(collection_info)] = collection_info
+    Generates the Ansible collection artifact data from a galaxy.yml and installs the artifact to a directory.
+    This should follow the same pattern as build_collection, but instead of creating an artifact, install it.
+    :param b_collection_output_path: The installation directory for the collection artifact.
+    :raises AnsibleError: If no collection metadata found.
+    """
+    collection_meta = artifacts_manager.get_direct_collection_meta(collection)
 
+    if 'build_ignore' not in collection_meta:  # installed collection, not src
+        # FIXME: optimize this? use a different process? copy instead of build?
+        collection_meta['build_ignore'] = []
+    collection_manifest = _build_manifest(**collection_meta)
+    file_manifest = _build_files_manifest(
+        b_collection_path,
+        collection_meta['namespace'], collection_meta['name'],
+        collection_meta['build_ignore'],
+    )
 
-def parse_scm(collection, version):
-    if ',' in collection:
-        collection, version = collection.split(',', 1)
-    elif version == '*' or not version:
-        version = 'HEAD'
+    collection_output_path = _build_collection_dir(b_collection_path, b_collection_output_path, collection_manifest, file_manifest)
 
-    if collection.startswith('git+'):
-        path = collection[4:]
-    else:
-        path = collection
-
-    path, fragment = urldefrag(path)
-    fragment = fragment.strip(os.path.sep)
-
-    if path.endswith(os.path.sep + '.git'):
-        name = path.split(os.path.sep)[-2]
-    elif '://' not in path and '@' not in path:
-        name = path
-    else:
-        name = path.split('/')[-1]
-        if name.endswith('.git'):
-            name = name[:-4]
-
-    return name, version, path, fragment
-
-
-def _download_file(url, b_path, expected_hash, validate_certs, headers=None):
-    urlsplit = os.path.splitext(to_text(url.rsplit('/', 1)[1]))
-    b_file_name = to_bytes(urlsplit[0], errors='surrogate_or_strict')
-    b_file_ext = to_bytes(urlsplit[1], errors='surrogate_or_strict')
-    b_file_path = tempfile.NamedTemporaryFile(dir=b_path, prefix=b_file_name, suffix=b_file_ext, delete=False).name
-
-    display.display("Downloading %s to %s" % (url, to_text(b_path)))
-    # Galaxy redirs downloads to S3 which reject the request if an Authorization header is attached so don't redir that
-    resp = open_url(to_native(url, errors='surrogate_or_strict'), validate_certs=validate_certs, headers=headers,
-                    unredirected_headers=['Authorization'], http_agent=user_agent())
-
-    with open(b_file_path, 'wb') as download_file:
-        actual_hash = _consume_file(resp, download_file)
-
-    if expected_hash:
-        display.vvvv("Validating downloaded file hash %s with expected hash %s" % (actual_hash, expected_hash))
-        if expected_hash != actual_hash:
-            raise AnsibleError("Mismatch artifact hash with downloaded file")
-
-    return b_file_path
+    display.display(
+        'Created collection for {coll!s} at {path!s}'.
+        format(coll=collection, path=collection_output_path)
+    )
 
 
 def _extract_tar_dir(tar, dirname, b_dest):
@@ -1539,25 +1212,45 @@ def _is_child_path(path, parent_path, link_name=None):
     return b_path == b_parent_path or b_path.startswith(b_parent_path + to_bytes(os.path.sep))
 
 
-def _consume_file(read_from, write_to=None):
-    bufsize = 65536
-    sha256_digest = sha256()
-    data = read_from.read(bufsize)
-    while data:
-        if write_to is not None:
-            write_to.write(data)
-            write_to.flush()
-        sha256_digest.update(data)
-        data = read_from.read(bufsize)
-
-    return sha256_digest.hexdigest()
-
-
-def get_galaxy_metadata_path(b_path):
-    b_default_path = os.path.join(b_path, b'galaxy.yml')
-    candidate_names = [b'galaxy.yml', b'galaxy.yaml']
-    for b_name in candidate_names:
-        b_path = os.path.join(b_path, b_name)
-        if os.path.exists(b_path):
-            return b_path
-    return b_default_path
+def _resolve_depenency_map(
+        requested_requirements,  # type: Iterable[Requirement]
+        galaxy_apis,  # type: Iterable[GalaxyAPI]
+        concrete_artifacts_manager,  # type: ConcreteArtifactsManager
+        no_deps,  # type: bool
+        allow_pre_release,  # type: bool
+):  # type: (...) -> Dict[str, Candidate]
+    """Return the resolved dependency map."""
+    collection_dep_resolver = build_collection_dependency_resolver(
+        galaxy_apis=galaxy_apis,
+        concrete_artifacts_manager=concrete_artifacts_manager,
+        with_deps=not no_deps,
+        with_pre_releases=allow_pre_release,
+    )
+    try:
+        return collection_dep_resolver.resolve(
+            requested_requirements,
+            max_rounds=2000000,  # NOTE: same constant pip uses
+        ).mapping
+    except CollectionDependencyResolutionImpossible as dep_exc:
+        conflict_causes = (
+            '* {req.fqcn!s}:{req.ver!s} ({dep_origin!s})'.format(
+                req=req_inf.requirement,
+                dep_origin='direct request'
+                if req_inf.parent is None
+                else 'dependency of {parent!s}'.
+                format(parent=req_inf.parent),
+            )
+            for req_inf in dep_exc.causes
+        )
+        error_msg_lines = chain(
+            (
+                'Failed to resolve the requested '
+                'dependencies map. Could not satisfy the following '
+                'requirements:',
+            ),
+            conflict_causes,
+        )
+        raise raise_from(  # NOTE: Leading "raise" is a hack for mypy bug #9717
+            AnsibleError('\n'.join(error_msg_lines)),
+            dep_exc,
+        )

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -448,12 +448,6 @@ def install_collections(
         coll for coll in existing_collections
         if coll.fqcn not in requested_requirements_names
     }
-    # NOTE: Pin installed collection versions that are
-    # NOTE: not directly requested via CLI if `--force-deps` is not set
-    requested_requirements |= (
-        set() if force_deps
-        else existing_non_requested_collections
-    )
 
     if not requested_requirements:
         display.display(
@@ -462,6 +456,13 @@ def install_collections(
             'consider using `--force`.'
         )
         return
+
+    # NOTE: Pin installed collection versions that are
+    # NOTE: not directly requested via CLI if `--force-deps` is not set
+    requested_requirements |= (
+        set() if force_deps
+        else existing_non_requested_collections
+    )
 
     with _display_progress("Process install dependency map"):
         # FIXME: Attempt to resolve deps with installed collections

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -977,22 +977,13 @@ def find_existing_collections(path, artifacts_manager):
             if not os.path.isdir(b_collection_path):
                 continue
 
-            b_manifest_path = os.path.join(b_collection_path, b'MANIFEST.json')
-            b_galaxy_yml_path = os.path.join(b_collection_path, b'galaxy.yml')
-
-            if os.path.exists(b_manifest_path):
-                req = Candidate.from_dir_path_as_installed(b_collection_path, artifacts_manager)
-            elif os.path.exists(b_galaxy_yml_path):
-                # allow badly formatted galaxy.yml files?
-                req = Candidate.from_dir_path_as_dev(b_collection_path, artifacts_manager)
-            else:
-                # no metadata was found
-                display.warning(
-                    "Collection at '%s' does not have a MANIFEST.json file, cannot detect version." % to_text(
-                        b_collection_path, errors='surrogate_or_strict'
-                    )
+            try:
+                req = Candidate.from_dir_path_as_unknown(
+                    b_collection_path,
+                    artifacts_manager,
                 )
-                req = Candidate.from_dir_path_as_unknown(b_collection_path)
+            except ValueError as val_err:
+                raise_from(AnsibleError(val_err), val_err)
 
             display.vvv(
                 "Found installed collection {coll!s} at '{path!s}'".

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -466,7 +466,7 @@ def _get_meta_from_dir(
 ):  # type: (...) -> Dict[str, Optional[Union[str, List[str], Dict[str, str]]]]
     try:
         return _get_meta_from_installed_dir(b_path)
-    except (LookupError, ValueError):
+    except LookupError:
         return _get_meta_from_src_dir(b_path)
 
 

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -109,8 +109,9 @@ class ConcreteArtifactsManager:
             display.vvv(
                 "Collection '{coll!s}' obtained from "
                 'server {server!s} {url!s}'.format(
-                    coll=collection, server=collection.src,
-                    url=collection.src.api_server,
+                    coll=collection, server=collection.src or 'Galaxy',
+                    url=collection.src.api_server if collection.src is not None
+                    else '',
                 )
             )
 

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -1,0 +1,593 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2020, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""Concrete collection candidate management helper module."""
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+import os
+import tarfile
+import subprocess
+from contextlib import contextmanager
+from hashlib import sha256
+from shutil import rmtree
+from tempfile import mkdtemp
+
+try:
+    from typing import TYPE_CHECKING
+except ImportError:
+    TYPE_CHECKING = False
+
+if TYPE_CHECKING:
+    from typing import (
+        Any,  # FIXME: !!!111
+        BinaryIO, Dict, IO,
+        Iterator, List, Optional,
+        Set, Tuple, Type, Union,
+    )
+
+    from ansible.galaxy.dependency_resolution.dataclasses import (
+        Candidate, Requirement,
+    )
+    from ansible.galaxy.token import GalaxyToken
+
+from ansible.errors import AnsibleError
+from ansible.galaxy import get_collections_galaxy_meta_info
+from ansible.galaxy.dependency_resolution.dataclasses import _GALAXY_YAML
+from ansible.galaxy.user_agent import user_agent
+from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.six.moves.urllib.error import URLError
+from ansible.module_utils.six.moves.urllib.parse import urldefrag
+from ansible.module_utils.six import raise_from
+from ansible.module_utils.urls import open_url
+from ansible.utils.display import Display
+
+import yaml
+
+
+display = Display()
+
+
+class ConcreteArtifactsManager:
+    def __init__(self, b_working_directory, validate_certs=True):
+        # type: (bytes, bool) -> None
+        self._validate_certs = validate_certs  # type: bool
+        self._artifact_cache = {}  # type: Dict[bytes, bytes]
+        self._galaxy_artifact_cache = {}  # type: Dict[Union[Candidate, Requirement], bytes]
+        self._artifact_meta_cache = {}  # type: Dict[bytes, Dict[str, Optional[Union[str, List[str], Dict[str, str]]]]]
+        self._galaxy_collection_cache = {}  # type: Dict[Union[Candidate, Requirement], Tuple[str, str, GalaxyToken]]
+        self._b_working_directory = b_working_directory  # type: bytes
+
+    def get_galaxy_artifact_path(self, collection):
+        # type: (Union[Candidate, Requirement]) -> bytes
+        assert not collection.is_concrete_artifact
+
+        try:
+            return self._galaxy_artifact_cache[collection]
+        except KeyError:
+            pass
+
+        try:
+            url, sha256_hash, token = self._galaxy_collection_cache[collection]
+        except KeyError as key_err:
+            raise_from(
+                RuntimeError(
+                    'The is no known source for {coll!s}'.
+                    format(coll=collection),
+                ),
+                key_err,
+            )
+
+        display.vvvv(
+            "Fetching a collection tarball for '{collection!s}' from "
+            'Ansible Galaxy'.format(collection=collection),
+        )
+
+        try:
+            b_artifact_path = _download_file(
+                url,
+                self._b_working_directory,
+                expected_hash=sha256_hash,
+                validate_certs=self._validate_certs,
+                token=token,
+            )  # type: bytes
+        except URLError as err:
+            raise_from(
+                AnsibleError(
+                    'Failed to download collection tar '
+                    "from '{coll_src!s}': {download_err!s}".
+                    format(
+                        coll_src=to_native(collection.src),
+                        download_err=to_native(err),
+                    ),
+                ),
+                err,
+            )
+
+        self._galaxy_artifact_cache[collection] = b_artifact_path
+        return b_artifact_path
+
+    def get_artifact_path(self, collection):
+        # type: (Union[Candidate, Requirement]) -> bytes
+        assert collection.is_concrete_artifact and collection.src is not None, (
+            'The contract is to have a collection candidate that is '
+            'unambiguously resolvable into a specific tarball '
+            'artifact pointer (a fileo or a dir on disk, an archive on '
+            'web or a buildable Git repository reference)'
+        )
+        try:
+            return self._artifact_cache[collection.src]
+        except KeyError:
+            pass
+
+        # NOTE: SCM needs to be special-cased as it may contain either
+        # NOTE: one collection in its root, or a number of top-level
+        # NOTE: collection directories instead.
+        # NOTE: The idea is to store the SCM collection as unpacked
+        # NOTE: directory structure under the temporary location and use
+        # NOTE: a "virtual" collection that has pinned requirements on
+        # NOTE: the directories under that SCM checkout that correspond
+        # NOTE: to collections.
+        # NOTE: This brings us to the idea that we need two separate
+        # NOTE: virtual Requirement/Candidate types --
+        # NOTE: (single) dir + (multidir) subdirs
+        if collection.is_url:
+            display.vvvv(
+                "Collection requirement '{collection!s}' is a URL "
+                'to a tar artifact'.format(collection=collection.fqcn),
+            )
+            try:
+                b_artifact_path = _download_file(
+                    collection.src,
+                    self._b_working_directory,
+                    expected_hash=None,  # NOTE: URLs don't support checksums
+                    validate_certs=self._validate_certs,
+                )
+            except URLError as err:
+                raise_from(
+                    AnsibleError(
+                        'Failed to download collection tar '
+                        "from '{coll_src!s}': {download_err!s}".
+                        format(
+                            coll_src=to_native(collection.src),
+                            download_err=to_native(err),
+                        ),
+                    ),
+                    err,
+                )
+        elif collection.is_scm:
+            b_artifact_path = _extract_collection_from_git(
+                collection.src,
+                collection.ver,
+                self._b_working_directory,
+            )
+        elif collection.is_file or collection.is_dir or collection.is_subdirs:
+            b_artifact_path = to_bytes(collection.src)
+        else:
+            # NOTE: This may happen `if collection.is_online_index_pointer`
+            raise RuntimeError(
+                'The artifact is of an unexpected type {art_type!s}'.
+                format(art_type=collection.type)
+            )
+
+        self._artifact_cache[collection.src] = b_artifact_path
+        return b_artifact_path
+
+    def _get_direct_collection_namespace(self, collection):
+        # type: (Candidate) -> Optional[str]
+        assert collection.is_concrete_artifact
+        return self.get_direct_collection_meta(collection)['namespace']  # type: ignore
+
+    def _get_direct_collection_name(self, collection):
+        # type: (Candidate) -> Optional[str]
+        assert collection.is_concrete_artifact
+        return self.get_direct_collection_meta(collection)['name']  # type: ignore
+
+    def get_direct_collection_fqcn(self, collection):
+        # type: (Candidate) -> Optional[str]
+        assert collection.is_concrete_artifact
+
+        if collection.is_virtual:
+            # NOTE: should it be something like "<virtual>"?
+            return None
+
+        return '.'.join((  # type: ignore
+            self._get_direct_collection_namespace(collection),  # type: ignore
+            self._get_direct_collection_name(collection),
+        ))
+
+    def get_direct_collection_version(self, collection):
+        # type: (Union[Candidate, Requirement]) -> str
+        assert collection.is_concrete_artifact
+        return self.get_direct_collection_meta(collection)['version']  # type: ignore
+
+    def get_direct_collection_dependencies(self, collection):
+        # type: (Union[Candidate, Requirement]) -> Dict[str, str]
+        assert collection.is_concrete_artifact
+        return self.get_direct_collection_meta(collection)['dependencies']  # type: ignore
+
+    def get_direct_collection_meta(self, collection):
+        # type: (Union[Candidate, Requirement]) -> Dict[str, Optional[Union[str, Dict[str, str], List[str]]]]
+        assert collection.is_concrete_artifact
+
+        try:  # FIXME: use unique collection identifier as a cache key?
+            return self._artifact_meta_cache[collection.src]
+        except KeyError:
+            b_artifact_path = self.get_artifact_path(collection)
+
+        if collection.is_url or collection.is_file:
+            collection_meta = _get_meta_from_tar(b_artifact_path)
+        elif collection.is_dir:  # should we just build a coll instead?
+            # FIXME: what if there's subdirs?
+            try:
+                collection_meta = _get_meta_from_dir(b_artifact_path)
+            except LookupError as lookup_err:
+                raise_from(
+                    AnsibleError(
+                        'Failed to find the collection dir deps: {err!s}'.
+                        format(err=to_native(lookup_err)),
+                    ),
+                    lookup_err,
+                )
+        elif collection.is_scm:
+            collection_meta = {
+                'name': None,
+                'namespace': None,
+                'dependencies': {to_native(b_artifact_path): '*'},
+                'version': '*',
+            }
+        elif collection.is_subdirs:
+            collection_meta = {
+                'name': None,
+                'namespace': None,
+                # NOTE: Dropping b_artifact_path since it's based on src anyway
+                'dependencies': dict.fromkeys(
+                    map(to_native, collection.namespace_collection_paths),
+                    '*',
+                ),
+                'version': '*',
+            }
+        else:
+            raise RuntimeError
+
+        self._artifact_meta_cache[collection.src] = collection_meta
+        return collection_meta
+
+    def save_collection_source(self, collection, url, sha256_hash, token):
+        # type: (Candidate, str, str, GalaxyToken) -> None
+        self._galaxy_collection_cache[collection] = url, sha256_hash, token
+
+    @classmethod
+    @contextmanager
+    def under_tmpdir(
+            cls,  # type: Type[ConcreteArtifactsManager]
+            temp_dir_base,  # type: str
+            validate_certs=True,  # type: bool
+    ):  # type: (...) -> Iterator[ConcreteArtifactsManager]
+        # NOTE: Can't use `with tempfile.TemporaryDirectory:`
+        # NOTE: because it's not in Python 2 stdlib.
+        temp_path = mkdtemp(
+            dir=to_bytes(temp_dir_base, errors='surrogate_or_strict'),
+        )
+        b_temp_path = to_bytes(temp_path, errors='surrogate_or_strict')
+        try:
+            yield cls(b_temp_path, validate_certs)
+        finally:
+            rmtree(b_temp_path)
+
+
+def parse_scm(collection, version):
+    if ',' in collection:
+        collection, version = collection.split(',', 1)
+    elif version == '*' or not version:
+        version = 'HEAD'
+
+    if collection.startswith('git+'):
+        path = collection[4:]
+    else:
+        path = collection
+
+    path, fragment = urldefrag(path)
+    fragment = fragment.strip(os.path.sep)
+
+    if path.endswith(os.path.sep + '.git'):
+        name = path.split(os.path.sep)[-2]
+    elif '://' not in path and '@' not in path:
+        name = path
+    else:
+        name = path.split('/')[-1]
+        if name.endswith('.git'):
+            name = name[:-4]
+
+    return name, version, path, fragment
+
+
+def _extract_collection_from_git(repo_url, coll_ver, b_path):
+    # FIXME: implement fragment_dir?
+    name, version, git_url, fragment = parse_scm(repo_url, coll_ver)
+    b_checkout_path = mkdtemp(
+        dir=b_path,
+        prefix=to_bytes(name, errors='surrogate_or_strict'),
+    )  # type: bytes
+    git_clone_cmd = 'git', 'clone', git_url, to_text(b_checkout_path)
+    # FIXME: '--depth', '1', '--branch', version
+    try:
+        subprocess.check_call(git_clone_cmd)
+    except subprocess.CalledProcessError as proc_err:
+        raise_from(
+            AnsibleError(  # should probably be LookupError
+                'Failed to clone a Git repository from `{repo_url!s}`.'.
+                format(repo_url=to_native(git_url)),
+            ),
+            proc_err,
+        )
+
+    git_switch_cmd = 'git', 'checkout', to_text(version)
+    try:
+        subprocess.check_call(git_switch_cmd, cwd=b_checkout_path)
+    except subprocess.CalledProcessError as proc_err:
+        raise_from(
+            AnsibleError(  # should probably be LookupError
+                'Failed to switch a cloned Git repo `{repo_url!s}` '
+                'to the requested revision `{commitish!s}`.'.
+                format(
+                    commitish=to_native(version),
+                    repo_url=to_native(git_url),
+                ),
+            ),
+            proc_err,
+        )
+
+    return (
+        os.path.join(b_checkout_path, to_bytes(fragment))
+        if fragment else b_checkout_path
+    )
+
+
+# FIXME: use random subdirs while preserving the file names
+def _download_file(url, b_path, expected_hash, validate_certs, token=None):
+    # type: (str, bytes, Optional[str], bool, GalaxyToken) -> bytes
+    # ^ NOTE: used in download and verify_collections ^
+    b_tarball_name = to_bytes(
+        url.rsplit('/', 1)[1], errors='surrogate_or_strict',
+    )
+    b_file_name = b_tarball_name[:-len('.tar.gz')]
+
+    b_tarball_dir = mkdtemp(
+        dir=b_path,
+        prefix=b'-'.join((b_file_name, b'')),
+    )  # type: bytes
+
+    b_file_path = os.path.join(b_tarball_dir, b_tarball_name)
+
+    display.display("Downloading %s to %s" % (url, to_text(b_tarball_dir)))
+    # NOTE: Galaxy redirects downloads to S3 which rejects the request
+    # NOTE: if an Authorization header is attached so don't redirect it
+    resp = open_url(
+        to_native(url, errors='surrogate_or_strict'),
+        validate_certs=validate_certs,
+        headers=None if token is None else token.headers(),
+        unredirected_headers=['Authorization'], http_agent=user_agent(),
+    )
+
+    with open(b_file_path, 'wb') as download_file:  # type: BinaryIO
+        actual_hash = _consume_file(resp, write_to=download_file)
+
+    if expected_hash:
+        display.vvvv(
+            'Validating downloaded file hash {actual_hash!s} with '
+            'expected hash {expected_hash!s}'.
+            format(actual_hash=actual_hash, expected_hash=expected_hash)
+        )
+        if expected_hash != actual_hash:
+            raise AnsibleError('Mismatch artifact hash with downloaded file')
+
+    return b_file_path
+
+
+def _consume_file(read_from, write_to=None):
+    # type: (BinaryIO, BinaryIO) -> str
+    bufsize = 65536
+    sha256_digest = sha256()
+    data = read_from.read(bufsize)
+    while data:
+        if write_to is not None:
+            write_to.write(data)
+            write_to.flush()
+        sha256_digest.update(data)
+        data = read_from.read(bufsize)
+
+    return sha256_digest.hexdigest()
+
+
+def _normalize_galaxy_yml_manifest(
+        galaxy_yml,  # type: Dict[str, Optional[Union[str, List[str], Dict[str, str]]]]
+        b_galaxy_yml_path,  # type: bytes
+):
+    # type: (...) -> Dict[str, Optional[Union[str, List[str], Dict[str, str]]]]
+    galaxy_yml_schema = (
+        get_collections_galaxy_meta_info()
+    )  # type: List[Dict[str, Any]]  # FIXME: <--
+    # FIXME: 👆maybe precise type: List[Dict[str, Union[bool, str, List[str]]]]
+
+    mandatory_keys = set()
+    string_keys = set()  # type: Set[str]
+    list_keys = set()  # type: Set[str]
+    dict_keys = set()  # type: Set[str]
+
+    for info in galaxy_yml_schema:
+        if info.get('required', False):
+            mandatory_keys.add(info['key'])
+
+        key_list_type = {
+            'str': string_keys,
+            'list': list_keys,
+            'dict': dict_keys,
+        }[info.get('type', 'str')]
+        key_list_type.add(info['key'])
+
+    all_keys = frozenset(list(mandatory_keys) + list(string_keys) + list(list_keys) + list(dict_keys))
+
+    set_keys = set(galaxy_yml.keys())
+    missing_keys = mandatory_keys.difference(set_keys)
+    if missing_keys:
+        raise AnsibleError("The collection galaxy.yml at '%s' is missing the following mandatory keys: %s"
+                           % (to_native(b_galaxy_yml_path), ", ".join(sorted(missing_keys))))
+
+    extra_keys = set_keys.difference(all_keys)
+    if len(extra_keys) > 0:
+        display.warning("Found unknown keys in collection galaxy.yml at '%s': %s"
+                        % (to_text(b_galaxy_yml_path), ", ".join(extra_keys)))
+
+    # Add the defaults if they have not been set
+    for optional_string in string_keys:
+        if optional_string not in galaxy_yml:
+            galaxy_yml[optional_string] = None
+
+    for optional_list in list_keys:
+        list_val = galaxy_yml.get(optional_list, None)
+
+        if list_val is None:
+            galaxy_yml[optional_list] = []
+        elif not isinstance(list_val, list):
+            galaxy_yml[optional_list] = [list_val]  # type: ignore
+
+    for optional_dict in dict_keys:
+        if optional_dict not in galaxy_yml:
+            galaxy_yml[optional_dict] = {}
+
+    return galaxy_yml
+
+
+def _get_meta_from_dir(
+        b_path,  # type: bytes
+):  # type: (...) -> Dict[str, Optional[Union[str, List[str], Dict[str, str]]]]
+    try:
+        return _get_meta_from_installed_dir(b_path)
+    except AnsibleError:
+        return _get_meta_from_src_dir(b_path)
+
+
+def _get_meta_from_src_dir(
+        b_path,  # type: bytes
+):  # type: (...) -> Dict[str, Optional[Union[str, List[str], Dict[str, str]]]]
+    galaxy_yml = os.path.join(b_path, _GALAXY_YAML)
+    if not os.path.isfile(galaxy_yml):
+        raise LookupError(
+            "The collection galaxy.yml path '{path!s}' does not exist.".
+            format(path=to_native(galaxy_yml))
+        )
+
+    with open(galaxy_yml, 'rb') as manifest_file_obj:
+        try:
+            manifest = yaml.safe_load(manifest_file_obj)
+        except yaml.error.YAMLError as yaml_err:
+            raise_from(
+                AnsibleError(
+                    "Failed to parse the galaxy.yml at '{path!s}' with "
+                    'the following error:\n{err_txt!s}'.
+                    format(
+                        path=to_native(galaxy_yml),
+                        err_txt=to_native(yaml_err),
+                    ),
+                ),
+                yaml_err,
+            )
+
+    return _normalize_galaxy_yml_manifest(manifest, galaxy_yml)
+
+
+def _get_meta_from_installed_dir(
+        b_path,  # type: bytes
+):  # type: (...) -> Dict[str, Optional[Union[str, List[str], Dict[str, str]]]]
+    n_manifest_json = 'MANIFEST.json'
+    b_manifest_json = to_bytes(n_manifest_json)
+    b_manifest_json_path = os.path.join(b_path, b_manifest_json)
+
+    try:
+        with open(b_manifest_json_path, 'rb') as manifest_fd:
+            b_manifest_txt = manifest_fd.read()
+    except OSError:
+        raise LookupError(
+            "The collection {manifest!s} path '{path!s}' does not exist.".
+            format(
+                manifest=n_manifest_json,
+                path=to_native(b_manifest_json_path),
+            )
+        )
+
+    manifest_txt = to_text(b_manifest_txt, errors='surrogate_or_strict')
+
+    try:
+        manifest = json.loads(manifest_txt)
+    except ValueError:
+        raise AnsibleError(
+            'Collection tar file member {member!s} does not '
+            'contain a valid json string.'.
+            format(member=n_manifest_json),
+        )
+    else:
+        return manifest['collection_info']
+
+
+def _get_meta_from_tar(
+        b_path,  # type: bytes
+):  # type: (...) -> Dict[str, Optional[Union[str, List[str], Dict[str, str]]]]
+    if not tarfile.is_tarfile(b_path):
+        raise AnsibleError(
+            "Collection artifact at '{path!s}' is not a valid tar file.".
+            format(path=to_native(b_path)),
+        )
+
+    n_manifest_json = 'MANIFEST.json'
+
+    with tarfile.open(b_path, mode='r') as collection_tar:  # type: tarfile.TarFile
+        try:
+            member = collection_tar.getmember(n_manifest_json)
+        except KeyError:
+            raise AnsibleError(
+                "Collection at '{path!s}' does not contain the "
+                'required file {manifest_file!s}.'.
+                format(
+                    path=to_native(b_path),
+                    manifest_file=n_manifest_json,
+                ),
+            )
+
+        with _tarfile_extract(collection_tar, member) as (_member, member_obj):
+            if member_obj is None:
+                raise AnsibleError(
+                    'Collection tar file does not contain '
+                    'member {member!s}'.format(member=n_manifest_json),
+                )
+
+            text_content = to_text(
+                member_obj.read(),
+                errors='surrogate_or_strict',
+            )
+
+            try:
+                manifest = json.loads(text_content)
+            except ValueError:
+                raise AnsibleError(
+                    'Collection tar file member {member!s} does not '
+                    'contain a valid json string.'.
+                    format(member=n_manifest_json),
+                )
+            return manifest['collection_info']
+
+
+@contextmanager
+def _tarfile_extract(
+        tar,  # type: tarfile.TarFile
+        member,  # type: tarfile.TarInfo
+):
+    # type: (...) -> Iterator[Tuple[tarfile.TarInfo, Optional[IO[bytes]]]]
+    tar_obj = tar.extractfile(member)
+    try:
+        yield member, tar_obj
+    finally:
+        if tar_obj is not None:
+            tar_obj.close()

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -466,7 +466,7 @@ def _get_meta_from_dir(
 ):  # type: (...) -> Dict[str, Optional[Union[str, List[str], Dict[str, str]]]]
     try:
         return _get_meta_from_installed_dir(b_path)
-    except AnsibleError:
+    except (LookupError, ValueError):
         return _get_meta_from_src_dir(b_path)
 
 

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -105,6 +105,14 @@ class ConcreteArtifactsManager:
                 ),
                 err,
             )
+        else:
+            display.vvv(
+                "Collection '{coll!s}' obtained from "
+                'server {server!s} {url!s}'.format(
+                    coll=collection, server=collection.src,
+                    url=collection.src.api_server,
+                )
+            )
 
         self._galaxy_artifact_cache[collection] = b_artifact_path
         return b_artifact_path

--- a/lib/ansible/galaxy/collection/galaxy_api_proxy.py
+++ b/lib/ansible/galaxy/collection/galaxy_api_proxy.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2020, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""A facade for interfacing with multiple Galaxy instances."""
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+
+try:
+    from typing import TYPE_CHECKING
+except ImportError:
+    TYPE_CHECKING = False
+
+if TYPE_CHECKING:
+    from typing import Dict, Iterable, Tuple
+    from ansible.galaxy.api import CollectionVersionMetadata
+    from ansible.galaxy.collection.concrete_artifact_manager import (
+        ConcreteArtifactsManager,
+    )
+    from ansible.galaxy.dependency_resolution.dataclasses import (
+        Candidate, Requirement,
+    )
+
+from ansible.galaxy.api import GalaxyAPI, GalaxyError
+
+
+class MultiGalaxyAPIProxy:
+    """A proxy that abstracts talking to multiple Galaxy instances."""
+
+    def __init__(self, apis, concrete_artifacts_manager):
+        # type: (Iterable[GalaxyAPI], ConcreteArtifactsManager) -> None
+        """Initialize the target APIs list."""
+        self._apis = apis
+        self._concrete_art_mgr = concrete_artifacts_manager
+
+    def get_collection_versions(self, requirement):
+        # type: (Requirement) -> Iterable[Tuple[str, GalaxyAPI]]
+        """Get a set of unique versions for FQCN on Galaxy servers."""
+        if requirement.is_concrete_artifact:
+            return {
+                (
+                    self._concrete_art_mgr.
+                    get_direct_collection_version(requirement),
+                    requirement.src,
+                ),
+            }
+
+        api_lookup_order = (
+            (requirement.src, )
+            if isinstance(requirement.src, GalaxyAPI)
+            else self._apis
+        )
+        return set(
+            (version, api)
+            for api in api_lookup_order
+            for version in api.get_collection_versions(
+                requirement.namespace, requirement.name,
+            )
+        )
+
+    def get_collection_version_metadata(self, collection_candidate):
+        # type: (Candidate) -> CollectionVersionMetadata
+        """Retrieve collection metadata of a given candidate."""
+
+        api_lookup_order = (
+            (collection_candidate.src, )
+            if isinstance(collection_candidate.src, GalaxyAPI)
+            else self._apis
+        )
+        for api in api_lookup_order:
+            try:
+                version_metadata = api.get_collection_version_metadata(
+                    collection_candidate.namespace,
+                    collection_candidate.name,
+                    collection_candidate.ver,
+                )
+            except GalaxyError as api_err:
+                last_err = api_err
+            else:
+                self._concrete_art_mgr.save_collection_source(
+                    collection_candidate,
+                    version_metadata.download_url,
+                    version_metadata.artifact_sha256,
+                    api.token,
+                )
+                return version_metadata
+
+        raise last_err
+
+    def get_collection_dependencies(self, collection_candidate):
+        # type: (Candidate) -> Dict[str, str]
+        # FIXME: return Requirement instances instead?
+        """Retrieve collection dependencies of a given candidate."""
+        if collection_candidate.is_concrete_artifact:
+            return (
+                self.
+                _concrete_art_mgr.
+                get_direct_collection_dependencies
+            )(collection_candidate)
+
+        return (
+            self.
+            get_collection_version_metadata(collection_candidate).
+            dependencies
+        )

--- a/lib/ansible/galaxy/dependency_resolution/__init__.py
+++ b/lib/ansible/galaxy/dependency_resolution/__init__.py
@@ -5,3 +5,42 @@
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
+
+try:
+    from typing import TYPE_CHECKING
+except ImportError:
+    TYPE_CHECKING = False
+
+if TYPE_CHECKING:
+    from typing import Iterable
+    from ansible.galaxy.api import GalaxyAPI
+    from ansible.galaxy.collection.concrete_artifact_manager import (
+        ConcreteArtifactsManager,
+    )
+
+from ansible.galaxy.collection.galaxy_api_proxy import MultiGalaxyAPIProxy
+from ansible.galaxy.dependency_resolution.providers import CollectionDependencyProvider
+from ansible.galaxy.dependency_resolution.reporters import CollectionDependencyReporter
+from ansible.galaxy.dependency_resolution.resolvers import CollectionDependencyResolver
+
+
+def build_collection_dependency_resolver(
+        galaxy_apis,  # type: Iterable[GalaxyAPI]
+        concrete_artifacts_manager,  # type: ConcreteArtifactsManager
+        with_deps=True,  # type: bool
+        with_pre_releases=False,  # type: bool
+):  # type: (...) -> CollectionDependencyResolver
+    """Return a collection dependency resolver.
+
+    The returned instance will have a ``resolve()`` method for
+    further consumption.
+    """
+    return CollectionDependencyResolver(
+        CollectionDependencyProvider(
+            apis=MultiGalaxyAPIProxy(galaxy_apis, concrete_artifacts_manager),
+            concrete_artifacts_manager=concrete_artifacts_manager,
+            with_deps=with_deps,
+            with_pre_releases=with_pre_releases,
+        ),
+        CollectionDependencyReporter(),
+    )

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -1,0 +1,391 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2020, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""Dependency structs."""
+# FIXME: add caching all over the place
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+import os
+from collections import namedtuple
+from glob import iglob
+from keyword import iskeyword  # used in _is_fqcn
+
+try:
+    from typing import TYPE_CHECKING
+except ImportError:
+    TYPE_CHECKING = False
+
+if TYPE_CHECKING:
+    from typing import Tuple
+
+import yaml
+
+from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.six.moves.urllib.parse import urlparse
+from ansible.module_utils.six import raise_from
+
+
+try:  # NOTE: py3/py2 compat
+    # FIXME: put somewhere into compat
+    _is_py_id = str.isidentifier  # type: ignore  # py2 mypy can't deal with it
+except AttributeError:  # Python 2
+    # FIXME: port this to AnsibleCollectionRef.is_valid_collection_name
+    from re import match as _match_pattern
+    from tokenize import Name as _VALID_IDENTIFIER_REGEX
+    _valid_identifier_string_regex = ''.join((_VALID_IDENTIFIER_REGEX, r'\Z'))
+
+    def _is_py_id(tested_str):
+        # Ref: https://stackoverflow.com/a/55802320/595220
+        return bool(_match_pattern(_valid_identifier_string_regex, tested_str))
+
+
+_ALLOW_CONCRETE_POINTER_IN_SOURCE = False  # NOTE: This is a feature flag
+_GALAXY_YAML = b'galaxy.yml'
+_MANIFEST_JSON = b'MANIFEST.json'
+
+
+def _is_collection_src_dir(dir_path):
+    b_dir_path = to_bytes(dir_path, errors='surrogate_or_strict')
+    return os.path.isfile(os.path.join(b_dir_path, _GALAXY_YAML))
+
+
+def _is_installed_collection_dir(dir_path):
+    b_dir_path = to_bytes(dir_path, errors='surrogate_or_strict')
+    return os.path.isfile(os.path.join(b_dir_path, _MANIFEST_JSON))
+
+
+def _is_collection_dir(dir_path):
+    return (
+        _is_installed_collection_dir(dir_path) or
+        _is_collection_src_dir(dir_path)
+    )
+
+
+def _find_collections_in_subdirs(dir_path):
+    b_dir_path = to_bytes(dir_path, errors='surrogate_or_strict')
+    galaxy_yml_glob_pattern = os.path.join(
+        b_dir_path,
+        # b'*',  # namespace is supposed to be top-level per spec
+        b'*',  # collection name
+        _GALAXY_YAML,
+    )
+    return (
+        os.path.dirname(galaxy_yml)
+        for galaxy_yml in iglob(galaxy_yml_glob_pattern)
+    )
+
+
+def _is_collection_namespace_dir(tested_str):
+    return any(_find_collections_in_subdirs(tested_str))
+
+
+def _is_file_path(tested_str):
+    return os.path.isfile(to_bytes(tested_str, errors='surrogate_or_strict'))
+
+
+def _is_http_url(tested_str):
+    return urlparse(tested_str).scheme.lower() in {'http', 'https'}
+
+
+def _is_git_url(tested_str):
+    return tested_str.startswith(('git+', 'git@'))
+
+
+def _is_concrete_artifact_pointer(tested_str):
+    return any(
+        predicate(tested_str)
+        for predicate in (
+            # NOTE: Maintain the checks to be sorted from light to heavy:
+            _is_git_url,
+            _is_http_url,
+            _is_file_path,
+            _is_collection_dir,
+            _is_collection_namespace_dir,
+        )
+    )
+
+
+def _is_fqcn(tested_str):
+    # FIXME: port this to AnsibleCollectionRef.is_valid_collection_name
+    if tested_str.count('.') != 1:
+        return False
+
+    return all(
+        # FIXME: keywords and identifiers are different in differnt Pythons
+        not iskeyword(ns_or_name) and _is_py_id(ns_or_name)
+        for ns_or_name in tested_str.split('.')
+    )
+
+
+class _ComputedReqKindsMixin:
+
+    @classmethod
+    def from_dir_path_as_installed(cls, dir_path, art_mgr):
+        if _is_installed_collection_dir(dir_path):
+            return cls.from_dir_path(dir_path, art_mgr)
+
+        raise AnsibleError(
+            '`{path!s}` must be an installed collection directory. It '
+            'does not appear to have a {manifest_name!s}. A '
+            '{manifest_name!s} is expected if the collection has been '
+            'built and installed via ansible-galaxy.'.
+            format(
+                path=to_native(dir_path),
+                manifest_name=to_native(_MANIFEST_JSON),
+            ),
+        )
+
+    @classmethod
+    def from_dir_path(cls, dir_path, art_mgr):
+        b_dir_path = to_bytes(dir_path, errors='surrogate_or_strict')
+        if not _is_collection_dir(b_dir_path):
+            raise ValueError(
+                '`dir_path` argument must be an installed or a source'
+                ' collection directory.',
+            )
+
+        tmp_inst_req = cls(None, None, dir_path, 'dir')
+        req_name = art_mgr.get_direct_collection_fqcn(tmp_inst_req)
+        req_version = art_mgr.get_direct_collection_version(tmp_inst_req)
+
+        return cls(req_name, req_version, dir_path, 'dir')
+
+    @classmethod
+    def from_string(cls, collection_input, artifacts_manager):
+        req = {}
+        if _is_concrete_artifact_pointer(collection_input):
+            # Arg is a file path or URL to a collection
+            req['name'] = collection_input
+        else:
+            req['name'], _sep, req['version'] = collection_input.partition(':')
+            if not req['version']:
+                del req['version']
+
+        return cls.from_requirement_dict(req, artifacts_manager)
+
+    @classmethod
+    def from_requirement_dict(cls, collection_req, art_mgr):
+        req_name = collection_req.get('name', None)
+        req_version = collection_req.get('version', '*')
+        req_type = collection_req.get('type')
+        # TODO: decide how to deprecate the old src API behavior
+        req_source = collection_req.get('source', None)
+
+        if req_type is None:
+            if (  # FIXME: decide on the future behavior:
+                    _ALLOW_CONCRETE_POINTER_IN_SOURCE
+                    and req_source is not None
+                    and _is_concrete_artifact_pointer(req_source)
+            ):
+                src_path = req_source
+            elif (
+                    req_name is not None
+                    and _is_concrete_artifact_pointer(req_name)
+            ):
+                src_path, req_name = req_name, None
+            elif req_name is not None and _is_fqcn(req_name):
+                req_type = 'galaxy'
+            else:
+                dir_tip_tmpl = (  # NOTE: leading LFs are for concat
+                    '\n\nTip: Make sure you are pointing to the right '
+                    'subdirectory — `{src!s}` looks like a directory '
+                    'but it is neither a collection, nor a namespace '
+                    'dir.'
+                )
+
+                if req_source is not None and os.path.isdir(req_source):
+                    tip = dir_tip_tmpl.format(src=req_source)
+                elif req_name is not None and os.path.isdir(req_name):
+                    tip = dir_tip_tmpl.format(src=req_name)
+                else:
+                    tip = ''
+
+                raise AnsibleError(  # NOTE: I'd prefer a ValueError instead
+                    'Neither the collection requirement entry key '
+                    "'name', nor 'source' point to a concrete "
+                    "resolvable collection artifact. Also 'name' is "
+                    'not an FQCN. A valid collection name must be in '
+                    'the format <namespace>.<collection>. Please make '
+                    'sure that the namespace and the collection name '
+                    ' contain characters from [a-zA-Z0-9_] only.'
+                    '{extra_tip!s}'.format(extra_tip=tip),
+                )
+
+        if req_type is None:
+            if _is_git_url(src_path):
+                req_type = 'git'
+                req_source = src_path
+            elif _is_http_url(src_path):
+                req_type = 'url'
+                req_source = src_path
+            elif _is_file_path(src_path):
+                req_type = 'file'
+                req_source = src_path
+            elif _is_collection_dir(src_path):
+                req_type = 'dir'
+                req_source = src_path
+            elif _is_collection_namespace_dir(src_path):
+                req_name = None  # No name for a virtual req or "namespace."?
+                req_type = 'subdirs'
+                req_source = src_path
+            else:
+                raise AnsibleError(  # NOTE: this is never supposed to be hit
+                    'Failed to automatically detect the collection '
+                    'requirement type.',
+                )
+
+        if req_type not in {'file', 'galaxy', 'git', 'url', 'dir', 'subdirs'}:
+            raise AnsibleError(
+                "The collection requirement entry key 'type' must be "
+                'one of file, galaxy, git, dir, subdirs, or url.'
+            )
+
+        if req_name is None and req_type == 'galaxy':
+            raise AnsibleError(
+                'Collections requirement entry should contain '
+                "the key 'name' if it's requested from a Galaxy-like "
+                'index server.',
+            )
+
+        tmp_inst_req = cls(req_name, req_version, req_source, req_type)
+
+        if req_type not in {'galaxy', 'subdirs'} and req_name is None:
+            req_name = art_mgr.get_direct_collection_fqcn(tmp_inst_req)  # TODO: fix the cache key in artifacts manager?
+
+        if req_type not in {'galaxy', 'subdirs'} and req_version == '*':
+            req_version = art_mgr.get_direct_collection_version(tmp_inst_req)
+
+        assert req_name is None or not os.path.isdir(req_name)
+        return cls(
+            req_name, req_version,
+            req_source, req_type,
+        )
+
+    def __repr__(self):
+        return (
+            '<{self!s} of type {coll_type!r} from {src!s}>'.
+            format(self=self, coll_type=self.type, src=self.src or 'Galaxy')
+        )
+
+    def __str__(self):
+        return to_native(self.__unicode__())
+
+    def __unicode__(self):
+        if self.fqcn is None:
+            return (
+                u'"virtual collection Git repo"' if self.is_scm
+                else u'"virtual collection namespace"'
+            )
+
+        return (
+            u'{fqcn!s}:{ver!s}'.
+            format(fqcn=to_text(self.fqcn), ver=to_text(self.ver))
+        )
+
+    def _get_separate_ns_n_name(self):  # FIXME: use LRU cache
+        return self.fqcn.split('.')
+
+    @property
+    def namespace(self):
+        if self.is_virtual:
+            raise TypeError('Virtual collections do not have a namespace')
+
+        return self._get_separate_ns_n_name()[0]
+
+    @property
+    def name(self):
+        if self.is_virtual:
+            raise TypeError('Virtual collections do not have a name')
+
+        return self._get_separate_ns_n_name()[-1]
+
+    @property
+    def canonical_package_id(self):
+        if not self.is_virtual:
+            return to_native(self.fqcn)
+
+        return (
+            '<virtual namespace from {src!s} of type {src_type!s}>'.
+            format(src=to_native(self.src), src_type=to_native(self.type))
+        )
+
+    @property
+    def is_virtual(self):
+        return self.is_scm or self.is_subdirs
+
+    @property
+    def is_file(self):
+        # FIXME: Make the checks less dynamic assuming that the type is
+        # FIXME: always set in the initializer (and is not None).
+        return self.type == 'file' or (
+            not self.type and
+            _is_file_path(self.src)
+        )
+
+    @property
+    def is_dir(self):
+        return self.type == 'dir' or (
+            not self.type and
+            _is_collection_dir(self.src)
+        )
+
+    @property
+    def namespace_collection_paths(self):
+        assert self.is_subdirs, 'This property only makes sense for namespaces'
+        return [
+            to_native(path)
+            for path in _find_collections_in_subdirs(self.src)
+        ]
+
+    @property
+    def is_subdirs(self):
+        return self.type == 'subdirs' or (
+            not self.type and
+            _is_collection_namespace_dir(self.src)
+        )
+
+    @property
+    def is_url(self):
+        return self.type == 'url' or (
+            not self.type and
+            _is_http_url(self.src)
+        )
+
+    @property
+    def is_scm(self):
+        return self.type == 'git' or (
+            not self.type and
+            _is_git_url(self.src)
+        )
+
+    @property
+    def is_concrete_artifact(self):
+        return any(
+            getattr(self, 'is_{prop!s}'.format(prop=prop), False)
+            for prop in (
+                # NOTE: Maintain the checks to be sorted from light to heavy:
+                'scm', 'url', 'file', 'dir', 'subdirs',
+            )
+        )
+
+    @property
+    def is_online_index_pointer(self):
+        return not self.is_concrete_artifact
+
+
+class Requirement(
+        _ComputedReqKindsMixin,
+        namedtuple('Requirement', ('fqcn', 'ver', 'src', 'type')),
+):
+    """An abstract requirement request."""
+
+
+class Candidate(
+        _ComputedReqKindsMixin,
+        namedtuple('Candidate', ('fqcn', 'ver', 'src', 'type'))
+):
+    """A concrete collection candidate with its version resolved."""

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -124,6 +124,25 @@ def _is_fqcn(tested_str):
 class _ComputedReqKindsMixin:
 
     @classmethod
+    def from_dir_path_as_unknown(cls, dir_path):
+        if os.path.isdir(dir_path):
+            return cls.from_dir_path_implicit(dir_path)
+        raise AnsibleError("The collection directory '{0}' doesn't exist".format(dir_path))
+
+    @classmethod
+    def from_dir_path_as_dev(cls, dir_path, art_mgr):
+        if _is_collection_src_dir(dir_path):
+            return cls.from_dir_path(dir_path, art_mgr)
+
+        raise AnsibleError(
+            '`{path!s}` must be an installed collection directory. It '
+            'does not appear to have a {file_name!s}. A '
+            '{file_name!s} is expected if the collection will be '
+            'built and installed via ansible-galaxy.'.
+            format(path=dir_path, file_name='galaxy.yml'),
+        )
+
+    @classmethod
     def from_dir_path_as_installed(cls, dir_path, art_mgr):
         if _is_installed_collection_dir(dir_path):
             return cls.from_dir_path(dir_path, art_mgr)
@@ -152,6 +171,14 @@ class _ComputedReqKindsMixin:
         req_name = art_mgr.get_direct_collection_fqcn(tmp_inst_req)
         req_version = art_mgr.get_direct_collection_version(tmp_inst_req)
 
+        return cls(req_name, req_version, dir_path, 'dir')
+
+    @classmethod
+    def from_dir_path_implicit(cls, dir_path):
+        # There is no metadata, but it isn't required for a functional collection. Determine the namespace.name from the path.
+        path_list = to_text(dir_path, errors='surrogate_or_strict').split(os.path.sep)
+        req_name = '%s.%s' % (path_list[-2], path_list[-1])
+        req_version = '*'
         return cls(req_name, req_version, dir_path, 'dir')
 
     @classmethod

--- a/lib/ansible/galaxy/dependency_resolution/errors.py
+++ b/lib/ansible/galaxy/dependency_resolution/errors.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2020, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""Dependency resolution exceptions."""
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from resolvelib.resolvers import (
+    ResolutionImpossible as CollectionDependencyResolutionImpossible,
+)

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -1,0 +1,220 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2020, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""Requirement provider interfaces."""
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import functools
+import operator
+
+try:
+    from typing import TYPE_CHECKING
+except ImportError:
+    TYPE_CHECKING = False
+
+if TYPE_CHECKING:
+    from typing import List, NamedTuple, Optional, Union
+    from ansible.galaxy.collection.concrete_artifact_manager import (
+        ConcreteArtifactsManager,
+    )
+    from ansible.galaxy.collection.galaxy_api_proxy import MultiGalaxyAPIProxy
+
+from ansible.galaxy.dependency_resolution.dataclasses import (
+    Candidate,
+    Requirement,
+)
+from ansible.galaxy.dependency_resolution.versioning import (
+    is_pre_release,
+    meets_requirements,
+)
+
+from resolvelib import AbstractProvider
+
+
+class CollectionDependencyProvider(AbstractProvider):
+    """Delegate class providing requirement interface for the resolver.
+    """
+
+    def __init__(
+            self,  # type: CollectionDependencyProvider
+            apis,  # type: MultiGalaxyAPIProxy
+            concrete_artifacts_manager=None,  # type: ConcreteArtifactsManager
+            with_deps=True,  # type: bool
+            with_pre_releases=False,  # type: bool
+    ):  # type: (...) -> None
+        r"""Initialize helper attributes.
+
+        :param api: An instance of the multiple Galaxy APIs wrapper
+        :type api: MultiGalaxyAPIProxy
+
+        :param concrete_artifacts_manager: An instance of the caching \
+                                           concrete artifacts manager
+        :type concrete_artifacts_manager: ConcreteArtifactsManager
+
+        :param with_deps: A flag specifying whether the resolver \
+                                  should attempt to pull-in the \
+                                  deps of the requested requirements. \
+                                  On by default.
+        :type with_deps: bool
+
+        :param with_pre_releases: A flag specifying whether the \
+                                  resolver should skip pre-releases. \
+                                  Off by default.
+        :type with_pre_releases: bool
+        """
+        self._api_proxy = apis
+        self._make_req_from_dict = functools.partial(
+            Requirement.from_requirement_dict,
+            art_mgr=concrete_artifacts_manager,
+        )
+        self._with_deps = with_deps
+        self._with_pre_releases = with_pre_releases
+
+    def identify(self, requirement_or_candidate):
+        # type: (Union[Candidate, Requirement]) -> str
+        """Given a requirement or candidate, return an identifier for it.
+
+        This is used to identify a requirement or candidate, e.g.
+        whether two requirements should have their specifier parts
+        merged, whether two candidates would conflict with each other
+        (because they have same name but different versions).
+        """
+        # FIXME: what to do if it is None? Rely on src? Use the whole tuple?
+        return requirement_or_candidate.canonical_package_id
+
+    def get_preference(
+            self,  # type: CollectionDependencyProvider
+            resolution,  # type: Optional[Candidate]
+            candidates,  # type: List[Candidate]
+            information,  # type: List[NamedTuple]
+    ):  # type: (...) -> int
+        """Produce a sort key function return value for given requirement based on preference.
+
+        FIXME: figure out the sort key
+        The preference is defined as "I think this requirement should be
+        resolved first". The lower the return value is, the more preferred
+        this group of arguments is.
+        :param resolution: Currently pinned candidate, or `None`.
+        :param candidates: A list of possible candidates.
+        :param information: A list of requirement information.
+        Each information instance is a named tuple with two entries:
+        * `requirement` specifies a requirement contributing to the current
+          candidate list
+        * `parent` specifies the candidate that provides (dependend on) the
+          requirement, or `None` to indicate a root requirement.
+        The preference could depend on a various of issues, including (not
+        necessarily in this order):
+        * Is this package pinned in the current resolution result?
+        * How relaxed is the requirement? Stricter ones should probably be
+          worked on first? (I don't know, actually.)
+        * How many possibilities are there to satisfy this requirement? Those
+          with few left should likely be worked on first, I guess?
+        * Are there any known conflicts for this requirement? We should
+          probably work on those with the most known conflicts.
+        A sortable value should be returned (this will be used as the `key`
+        parameter of the built-in sorting function). The smaller the value is,
+        the more preferred this requirement is (i.e. the sorting function
+        is called with `reverse=False`).
+        """
+        # NOTE: this mirrors the current implementation in pip and pipenv
+        # FIXME: Invent something better
+        return len(candidates)
+
+    def find_matches(self, requirements):
+        # type: (List[Requirement]) -> List[Candidate]
+        """Find all possible candidates that satisfy the given requirements.
+
+        This should try to get candidates based on the requirements' types.
+        For VCS, local, and archive requirements, the one-and-only match is
+        returned, and for a "named" requirement, the index(es) should be
+        consulted to find concrete candidates for this requirement.
+        :param requirements: A collection of requirements which all of the
+            returned candidates must match. All requirements are guaranteed to
+            have the same identifier. The collection is never empty.
+        :returns: An iterable that orders candidates by preference, e.g. the
+            most preferred candidate should come first.
+        """
+        assert requirements, 'Broken contract of having non-empty requirements'
+
+        # FIXME: The first requirement may be a Git repo followed by
+        # FIXME: its cloned tmp dir. Using only the first one creates
+        # FIXME: loops that prevent any further dependency exploration.
+        # FIXME: We need to figure out how to prevent this.
+        first_req = requirements[0]
+        fqcn = first_req.fqcn
+        # The fqcn is guaranteed to be the same
+        coll_versions = self._api_proxy.get_collection_versions(first_req)
+        if first_req.is_concrete_artifact:
+            # FIXME: do we assume that all the following artifacts are also concrete?
+            # FIXME: does using fqcn==None cause us problems here?
+
+            return [
+                Candidate(fqcn, version, _none_src_server, first_req.type)
+                for version, _none_src_server in coll_versions
+            ]
+
+        return sorted(
+            {
+                candidate for candidate in (
+                    Candidate(fqcn, version, src_server, 'galaxy')  # FIXME: type=galaxy?
+                    for version, src_server in coll_versions
+                    if self._with_pre_releases or
+                    not is_pre_release(version)
+                )
+                for requirement in requirements
+                if self.is_satisfied_by(requirement, candidate)
+                # and ( # FIXME
+                #     requirement.src is None or
+                #     requirement.src == candidate.src
+                # )
+            },
+            key=operator.attrgetter('ver', 'src'),
+            reverse=True,  # prefer newer versions over older ones
+        )
+
+    def is_satisfied_by(self, requirement, candidate):
+        # type: (Requirement, Candidate) -> bool
+        """Whether the given requirement can be satisfied by a candidate.
+        The candidate is guarenteed to have been generated from the
+        requirement.
+        A boolean should be returned to indicate whether `candidate` is a
+        viable solution to the requirement.
+        """
+        # NOTE: This is a set of Pipenv-inspired optimizations. Ref:
+        # https://github.com/sarugaku/passa/blob/2ac00f1/src/passa/models/providers.py#L58-L74
+        if (
+                requirement.is_virtual or
+                candidate.is_virtual or
+                requirement.ver == '*'
+        ):
+            return True
+
+        return meets_requirements(
+            version=candidate.ver,
+            requirements=requirement.ver,
+        )
+
+    def get_dependencies(self, candidate):
+        # type: (Candidate) -> List[Candidate]
+        r"""Get dependencies of a candidate.
+
+        :returns: A collection of requirements that `candidate` \
+                  specifies as its dependencies.
+        :rtype: list[Candidate]
+        """
+        if not self._with_deps:
+            return []
+
+        # FIXME: If there's several galaxy servers set, there may be a
+        # FIXME: situation when the metadata of the same collection
+        # FIXME: differs. So how do we resolve this case? Priority?
+        # FIXME: Taking into account a pinned hash? Exploding on
+        # FIXME: any differences?
+        # NOTE: The underlying implmentation currently uses first found
+        req_map = self._api_proxy.get_collection_dependencies(candidate)
+        return [
+            self._make_req_from_dict({'name': dep_name, 'version': dep_req})
+            for dep_name, dep_req in req_map.items()
+        ]

--- a/lib/ansible/galaxy/dependency_resolution/reporters.py
+++ b/lib/ansible/galaxy/dependency_resolution/reporters.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2020, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""Requiement reporter implementations."""
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from resolvelib import BaseReporter
+
+
+class CollectionDependencyReporter(BaseReporter):
+    """A dependency reporter for Ansible Collections.
+
+    This is a proxy class allowing us to abstract away importing resolvelib
+    outside of the `ansible.galaxy.dependency_resolution` Python package.
+    """

--- a/lib/ansible/galaxy/dependency_resolution/resolvers.py
+++ b/lib/ansible/galaxy/dependency_resolution/resolvers.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2020, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""Requirement resolver implementations."""
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from resolvelib import Resolver
+
+
+class CollectionDependencyResolver(Resolver):
+    """A dependency resolver for Ansible Collections.
+
+    This is a proxy class allowing us to abstract away importing resolvelib
+    outside of the `ansible.galaxy.dependency_resolution` Python package.
+    """

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,10 @@
+[mypy]
+follow_imports = skip
+
+[mypy-ansible.module_utils.six.*]
+#follow_imports = skip
+ignore_missing_imports = True
+
+[mypy-resolvelib.*]
+#follow_imports = skip
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ jinja2
 PyYAML
 cryptography
 packaging
+resolvelib >= 0.5.2  # New dependency resolver that pip>=20.3 uses

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ jinja2
 PyYAML
 cryptography
 packaging
-resolvelib >= 0.5.2  # New dependency resolver that pip>=20.3 uses
+resolvelib >= 0.5.3  # New dependency resolver that pip>=20.3 uses

--- a/test/integration/targets/ansible-galaxy-collection/files/test_module.py
+++ b/test/integration/targets/ansible-galaxy-collection/files/test_module.py
@@ -1,0 +1,81 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2016, Toshio Kuratomi <tkuratomi@ansible.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: ping
+version_added: historical
+short_description: Try to connect to host, verify a usable python and return C(pong) on success
+description:
+   - A trivial test module, this module always returns C(pong) on successful
+     contact. It does not make sense in playbooks, but it is useful from
+     C(/usr/bin/ansible) to verify the ability to login and that a usable Python is configured.
+   - This is NOT ICMP ping, this is just a trivial test module that requires Python on the remote-node.
+   - For Windows targets, use the M(ansible.windows.win_ping) module instead.
+   - For Network targets, use the M(ansible.netcommon.net_ping) module instead.
+options:
+  data:
+    description:
+      - Data to return for the C(ping) return value.
+      - If this parameter is set to C(crash), the module will cause an exception.
+    type: str
+    default: pong
+seealso:
+- module: ansible.netcommon.net_ping
+- module: ansible.windows.win_ping
+author:
+    - Ansible Core Team
+    - Michael DeHaan
+'''
+
+EXAMPLES = '''
+# Test we can logon to 'webservers' and execute python with json lib.
+# ansible webservers -m ping
+
+- name: Example from an Ansible Playbook
+  ping:
+
+- name: Induce an exception to see what happens
+  ping:
+    data: crash
+'''
+
+RETURN = '''
+ping:
+    description: value provided with the data parameter
+    returned: success
+    type: str
+    sample: pong
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            data=dict(type='str', default='pong'),
+        ),
+        supports_check_mode=True
+    )
+
+    if module.params['data'] == 'crash':
+        raise Exception("boom")
+
+    result = dict(
+        ping=module.params['data'],
+    )
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/ansible-galaxy-collection/tasks/download.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/download.yml
@@ -69,7 +69,8 @@
     dest: '{{ galaxy_dir }}/download/download.yml'
 
 - name: download collection with req to custom dir
-  command: ansible-galaxy collection download -r '{{ galaxy_dir }}/download/download.yml' -s galaxy_ng -p '{{ galaxy_dir }}/download/collections-custom' {{ galaxy_verbosity }}
+  # FIXME: --pre should be implicit when exact prerelease version is given
+  command: ansible-galaxy collection download -r '{{ galaxy_dir }}/download/download.yml' -s galaxy_ng -p '{{ galaxy_dir }}/download/collections-custom' {{ galaxy_verbosity }} --pre
   register: download_req_custom_path
 
 - name: get result of download collection with req to custom dir

--- a/test/integration/targets/ansible-galaxy-collection/tasks/download.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/download.yml
@@ -69,8 +69,7 @@
     dest: '{{ galaxy_dir }}/download/download.yml'
 
 - name: download collection with req to custom dir
-  # FIXME: --pre should be implicit when exact prerelease version is given
-  command: ansible-galaxy collection download -r '{{ galaxy_dir }}/download/download.yml' -s galaxy_ng -p '{{ galaxy_dir }}/download/collections-custom' {{ galaxy_verbosity }} --pre
+  command: ansible-galaxy collection download -r '{{ galaxy_dir }}/download/download.yml' -s galaxy_ng -p '{{ galaxy_dir }}/download/collections-custom' {{ galaxy_verbosity }}
   register: download_req_custom_path
 
 - name: get result of download collection with req to custom dir

--- a/test/integration/targets/ansible-galaxy-collection/tasks/download.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/download.yml
@@ -19,9 +19,9 @@
 - name: assert download collection with multiple dependencies
   assert:
     that:
-    - '"Downloading collection ''parent_dep.parent_collection'' to" in download_collection.stdout'
-    - '"Downloading collection ''child_dep.child_collection'' to" in download_collection.stdout'
-    - '"Downloading collection ''child_dep.child_dep2'' to" in download_collection.stdout'
+    - '"Downloading collection ''parent_dep.parent_collection:1.0.0'' to" in download_collection.stdout'
+    - '"Downloading collection ''child_dep.child_collection:0.9.9'' to" in download_collection.stdout'
+    - '"Downloading collection ''child_dep.child_dep2:1.2.2'' to" in download_collection.stdout'
     - download_collection_actual.examined == 4
     - download_collection_actual.matched == 4
     - (download_collection_actual.files[0].path | basename) in ['requirements.yml', 'child_dep-child_dep2-1.2.2.tar.gz', 'child_dep-child_collection-0.9.9.tar.gz', 'parent_dep-parent_collection-1.0.0.tar.gz']
@@ -81,7 +81,7 @@
 - name: assert download collection with multiple dependencies
   assert:
     that:
-    - '"Downloading collection ''namespace1.name1'' to" in download_req_custom_path.stdout'
+    - '"Downloading collection ''namespace1.name1:1.1.0-beta.1'' to" in download_req_custom_path.stdout'
     - download_req_custom_path_actual.examined == 2
     - download_req_custom_path_actual.matched == 2
     - (download_req_custom_path_actual.files[0].path | basename) in ['requirements.yml', 'namespace1-name1-1.1.0-beta.1.tar.gz']
@@ -138,5 +138,5 @@
 
     - assert:
         that:
-        - '"Downloading collection ''ansible_test.my_collection'' to" in download_collection.stdout'
+        - '"Downloading collection ''ansible_test.my_collection:1.0.0'' to" in download_collection.stdout'
         - download_collection_actual.stat.exists

--- a/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
@@ -129,7 +129,9 @@
 - name: expect failure with dep resolution failure
   command:  ansible-galaxy collection install fail_namespace.fail_collection -s {{ test_name }} {{ galaxy_verbosity }}
   register: fail_dep_mismatch
-  failed_when: '"Cannot meet dependency requirement ''fail_dep2.name:<0.0.5'' for collection fail_namespace.fail_collection" not in fail_dep_mismatch.stderr'
+  failed_when:
+  - '"Could not satisfy the following requirements" not in fail_dep_mismatch.stderr'
+  - '" fail_dep2.name:<0.0.5 (dependency of fail_namespace.fail_collection:2.1.2)" not in fail_dep_mismatch.stderr'
 
 - name: Find artifact url for namespace3.name
   uri:

--- a/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
@@ -40,7 +40,7 @@
 - name: assert install existing without --force - {{ test_name }}
   assert:
     that:
-    - '"Skipping ''namespace1.name1'' as it is already installed" in install_existing_no_force.stdout'
+    - '"Nothing to do. All requested collections are already installed" in install_existing_no_force.stdout'
 
 - name: install existing with --force - {{ test_name }}
   command: ansible-galaxy collection install namespace1.name1 -s '{{ test_name }}' --force {{ galaxy_verbosity }}

--- a/test/integration/targets/ansible-galaxy-collection/tasks/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/main.yml
@@ -178,3 +178,18 @@
     apply:
       environment:
         ANSIBLE_CONFIG: '{{ galaxy_dir }}/ansible.cfg'
+
+- name: run ansible-galaxy collection verify tests for {{ test_name }}
+  include_tasks: verify.yml
+  args:
+    apply:
+      environment:
+        ANSIBLE_CONFIG: '{{ galaxy_dir }}/ansible.cfg'
+  vars:
+    test_name: '{{ item.name }}'
+    test_server: '{{ item.server }}'
+    vX: '{{ "v3/" if item.v3|default(false) else "v2/" }}'
+  loop:
+  - name: galaxy_ng
+    server: '{{ galaxy_ng_server }}'
+    v3: true

--- a/test/integration/targets/ansible-galaxy-collection/tasks/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/main.yml
@@ -107,7 +107,6 @@
   - name: pulp_v3
     server: '{{ pulp_server }}published/api/'
     v3: true
-  when: False  # FIXME: temporarily skip failing tests
 
 - name: publish collection with a dep on another server
   setup_collections:

--- a/test/integration/targets/ansible-galaxy-collection/tasks/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/main.yml
@@ -107,6 +107,7 @@
   - name: pulp_v3
     server: '{{ pulp_server }}published/api/'
     v3: true
+  when: False  # FIXME: temporarily skip failing tests
 
 - name: publish collection with a dep on another server
   setup_collections:
@@ -163,6 +164,7 @@
   environment:
     ANSIBLE_CONFIG: '{{ galaxy_dir }}/ansible.cfg'
   register: missing_fallback
+  when: False  # FIXME: temporarily skip failing tests
 
 - name: assert test install fallback on server list
   assert:
@@ -171,6 +173,7 @@
     - '"Collection ''fake.fake'' is not available from server pulp_v2" in missing_fallback.stdout'
     - '"Collection ''fake.fake'' is not available from server pulp_v3" in missing_fallback.stdout'
     - '"Collection ''fake.fake'' is not available from server galaxy_ng" in missing_fallback.stdout'
+  when: False  # FIXME: temporarily skip failing tests
 
 - name: run ansible-galaxy collection download tests
   include_tasks: download.yml

--- a/test/integration/targets/ansible-galaxy-collection/tasks/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/main.yml
@@ -145,11 +145,19 @@
 - name: assert result of install collection with dep on another server
   assert:
     that:
-    - '"''secondary.name'' obtained from server secondary" in install_cross_dep.stdout'
+    - >-
+      "'secondary.name:1.0.0' obtained from server secondary"
+      in install_cross_dep.stdout
     # pulp_v2 is highest in the list so it will find it there first
-    - '"''parent_dep.parent_collection'' obtained from server pulp_v2" in install_cross_dep.stdout'
-    - '"''child_dep.child_collection'' obtained from server pulp_v2" in install_cross_dep.stdout'
-    - '"''child_dep.child_dep2'' obtained from server pulp_v2" in install_cross_dep.stdout'
+    - >-
+      "'parent_dep.parent_collection:1.0.0' obtained from server pulp_v2"
+      in install_cross_dep.stdout
+    - >-
+      "'child_dep.child_collection:0.9.9' obtained from server pulp_v2"
+      in install_cross_dep.stdout
+    - >-
+      "'child_dep.child_dep2:1.2.2' obtained from server pulp_v2"
+      in install_cross_dep.stdout
     - (install_cross_dep_actual.results[0].content | b64decode | from_json).collection_info.version == '1.0.0'
     - (install_cross_dep_actual.results[1].content | b64decode | from_json).collection_info.version == '1.0.0'
     - (install_cross_dep_actual.results[2].content | b64decode | from_json).collection_info.version == '0.9.9'

--- a/test/integration/targets/ansible-galaxy-collection/tasks/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/main.yml
@@ -162,26 +162,6 @@
     - (install_cross_dep_actual.results[2].content | b64decode | from_json).collection_info.version == '0.9.9'
     - (install_cross_dep_actual.results[3].content | b64decode | from_json).collection_info.version == '1.2.2'
 
-# fake.fake does not exist but we check the output to ensure it checked all 3
-# servers defined in the config. We hardcode to -vvv as that's what level the
-# message is shown
-- name: test install fallback on server list
-  command: ansible-galaxy collection install fake.fake -vvv
-  ignore_errors: yes
-  environment:
-    ANSIBLE_CONFIG: '{{ galaxy_dir }}/ansible.cfg'
-  register: missing_fallback
-  when: False  # FIXME: temporarily skip failing tests
-
-- name: assert test install fallback on server list
-  assert:
-    that:
-    - missing_fallback.rc == 1
-    - '"Collection ''fake.fake'' is not available from server pulp_v2" in missing_fallback.stdout'
-    - '"Collection ''fake.fake'' is not available from server pulp_v3" in missing_fallback.stdout'
-    - '"Collection ''fake.fake'' is not available from server galaxy_ng" in missing_fallback.stdout'
-  when: False  # FIXME: temporarily skip failing tests
-
 - name: run ansible-galaxy collection download tests
   include_tasks: download.yml
   args:

--- a/test/integration/targets/ansible-galaxy-collection/tasks/verify.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/verify.yml
@@ -1,0 +1,187 @@
+- name: create an empty collection skeleton
+  command: ansible-galaxy collection init ansible_test.verify
+  args:
+    chdir: '{{ galaxy_dir }}/scratch'
+
+- name: build the collection
+  command: ansible-galaxy collection build scratch/ansible_test/verify
+  args:
+    chdir: '{{ galaxy_dir }}'
+
+- name: publish collection - {{ test_name }}
+  command: ansible-galaxy collection publish ansible_test-verify-1.0.0.tar.gz -s {{ test_name }} {{ galaxy_verbosity }}
+  args:
+    chdir: '{{ galaxy_dir }}'
+
+- name: test verifying a tarfile
+  command: ansible-galaxy collection verify {{ galaxy_dir }}/ansible_test-verify-1.0.0.tar.gz
+  register: verify
+  ignore_errors: yes
+
+- assert:
+    that:
+      - verify.failed
+      - "'is not a valid collection name. The format namespace.name is expected.' in verify.stderr"
+
+- name: install the collection from the server
+  command: ansible-galaxy collection install ansible_test.verify:1.0.0
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}'
+
+- name: verify the installed collection against the server
+  command: ansible-galaxy collection verify ansible_test.verify:1.0.0
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}'
+  register: verify
+
+- assert:
+    that:
+      - verify is success
+      - "'Collection ansible_test.verify contains modified content' not in verify.stdout"
+
+- name: verify a collection that doesn't appear to be installed
+  command: ansible-galaxy collection verify ansible_test.verify:1.0.0
+  register: verify
+  ignore_errors: true
+
+- assert:
+    that:
+      - verify.failed
+      - "'Collection ansible_test.verify is not installed in any of the collection paths.' in verify.stderr"
+
+- name: create a modules directory
+  file:
+    state: directory
+    path: '{{ galaxy_dir }}/scratch/ansible_test/verify/plugins/modules'
+
+- name: add a module to the collection
+  copy:
+    src: test_module.py
+    dest: '{{ galaxy_dir }}/scratch/ansible_test/verify/plugins/modules/test_module.py'
+
+- name: update the collection version
+  lineinfile:
+    regexp: "version: *"
+    line: "version: '2.0.0'"
+    path: '{{ galaxy_dir }}/scratch/ansible_test/verify/galaxy.yml'
+
+- name: build the new version
+  command: ansible-galaxy collection build scratch/ansible_test/verify
+  args:
+    chdir: '{{ galaxy_dir }}'
+
+- name: publish the new version
+  command: ansible-galaxy collection publish ansible_test-verify-2.0.0.tar.gz -s {{ test_name }} {{ galaxy_verbosity }}
+  args:
+    chdir: '{{ galaxy_dir }}'
+
+- name: verify a version of a collection that isn't installed
+  command: ansible-galaxy collection verify ansible_test.verify:2.0.0
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}'
+  register: verify
+
+- assert:
+    that:
+      - '"ansible_test.verify has the version ''1.0.0'' but is being compared to ''2.0.0''" in verify.stdout'
+
+- name: install the new version from the server
+  command: ansible-galaxy collection install ansible_test.verify:2.0.0 --force
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}'
+
+- name: verify the installed collection against the server
+  command: ansible-galaxy collection verify ansible_test.verify:2.0.0
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}'
+  register: verify
+
+- assert:
+    that:
+      - "'Collection ansible_test.verify contains modified content' not in verify.stdout"
+
+# Test a modified collection
+
+- set_fact:
+    manifest_path: '{{ galaxy_dir }}/ansible_collections/ansible_test/verify/MANIFEST.json'
+    file_manifest_path: '{{ galaxy_dir }}/ansible_collections/ansible_test/verify/FILES.json'
+    module_path: '{{ galaxy_dir }}/ansible_collections/ansible_test/verify/plugins/modules/test_module.py'
+
+- name: load the FILES.json
+  set_fact:
+    files_manifest: "{{ lookup('file', file_manifest_path) | from_json }}"
+
+- name: get the real checksum of a particular module
+  stat:
+    path: "{{ module_path }}"
+    checksum_algorithm: sha256
+  register: file
+
+- assert:
+    that:
+      - "file.stat.checksum == item.chksum_sha256"
+  loop: "{{ files_manifest.files }}"
+  when: "item.name == 'plugins/modules/aws_s3.py'"
+
+- name: append a newline to the module to modify the checksum
+  shell: "echo '' >> {{ module_path }}"
+
+- name: get the new checksum
+  stat:
+    path: "{{ module_path }}"
+    checksum_algorithm: sha256
+  register: updated_file
+
+- assert:
+    that:
+      - "updated_file.stat.checksum != file.stat.checksum"
+
+- name: test verifying checksumes of the modified collection
+  command: ansible-galaxy collection verify ansible_test.verify:2.0.0
+  register: verify
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}'
+
+- assert:
+    that:
+      - "'Collection ansible_test.verify contains modified content in the following files:\nansible_test.verify\n    plugins/modules/test_module.py' in verify.stdout"
+
+- name: modify the FILES.json to match the new checksum
+  lineinfile:
+    path: "{{ file_manifest_path }}"
+    regexp: '   "chksum_sha256": "{{ file.stat.checksum }}",'
+    line: '   "chksum_sha256": "{{ updated_file.stat.checksum }}",'
+    state: present
+  diff: true
+
+- name: ensure a modified FILES.json is validated
+  command: ansible-galaxy collection verify ansible_test.verify:2.0.0
+  register: verify
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}'
+
+- assert:
+    that:
+      - "'Collection ansible_test.verify contains modified content in the following files:\nansible_test.verify\n    FILES.json' in verify.stdout"
+
+- name: get the checksum of the FILES.json
+  stat:
+    path: "{{ file_manifest_path }}"
+    checksum_algorithm: sha256
+  register: manifest_info
+
+- name: modify the MANIFEST.json to contain a different checksum for FILES.json
+  lineinfile:
+    regexp: '  "chksum_sha256": *'
+    path: "{{ manifest_path }}"
+    line: ' "chksum_sha256": "{{ manifest_info.stat.checksum }}",'
+
+- name: ensure the MANIFEST.json is validated against the uncorrupted file from the server
+  command: ansible-galaxy collection verify ansible_test.verify:2.0.0
+  register: verify
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}'
+
+- assert:
+    that:
+      - "'Collection ansible_test.verify contains modified content in the following files:\nansible_test.verify\n    MANIFEST.json' in verify.stdout"

--- a/test/integration/targets/ansible-galaxy-collection/tasks/verify.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/verify.yml
@@ -21,7 +21,8 @@
 - assert:
     that:
       - verify.failed
-      - "'is not a valid collection name. The format namespace.name is expected.' in verify.stderr"
+      - >-
+        "ERROR! 'file' type is not supported. The format namespace.name is expected." in verify.stderr
 
 - name: install the collection from the server
   command: ansible-galaxy collection install ansible_test.verify:1.0.0

--- a/test/lib/ansible_test/_data/requirements/integration.txt
+++ b/test/lib/ansible_test/_data/requirements/integration.txt
@@ -4,3 +4,4 @@ junit-xml
 ordereddict ; python_version < '2.7'
 packaging
 pyyaml
+resolvelib

--- a/test/lib/ansible_test/_data/requirements/units.txt
+++ b/test/lib/ansible_test/_data/requirements/units.txt
@@ -5,3 +5,4 @@ pytest
 pytest-mock
 pytest-xdist
 pyyaml
+resolvelib

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -1,5 +1,6 @@
 jinja2
 pyyaml
+resolvelib
 sphinx
 sphinx-notfound-page
 straight.plugin

--- a/test/sanity/code-smell/mypy.json
+++ b/test/sanity/code-smell/mypy.json
@@ -1,0 +1,4 @@
+{
+    "no_targets": true,
+    "output": "path-line-column-message"
+}

--- a/test/sanity/code-smell/mypy.py
+++ b/test/sanity/code-smell/mypy.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+"""Make sure the type annotations are correct across packages."""
+
+import subprocess
+import sys
+
+
+def run_mypy(python_version=None):
+    """Execute mypy against a given Python version.
+
+    This function proxies mypy's return code and filters out
+    the output so that `ansible-test` wouldn't get confused.
+    """
+    mypy_cmd = (
+        sys.executable, '-m', 'mypy',
+        *(
+            () if python_version is None
+            else ('--python-version', python_version)
+        ),
+        'lib/ansible/galaxy/collection/',
+        'lib/ansible/galaxy/dependency_resolution',
+    )
+    try:
+        mypy_out = subprocess.check_output(mypy_cmd, universal_newlines=True)
+    except subprocess.CalledProcessError as proc_err:
+        mypy_out = proc_err.output
+        return_code = proc_err.returncode
+    else:
+        return_code = 0
+
+    if not return_code:
+        # NOTE: Interrupt because `ansible-test sanity` runner treats any
+        # NOTE: output as a linting failure.
+        return return_code
+
+    print(
+        'Results of type checking with mypy against '
+        f'{python_version or "unspecified"!s} Python '
+        f'(return code {return_code!s}):',
+        file=sys.stderr,
+    )
+    for line in mypy_out.splitlines():
+        if line.startswith((u'Success: no issues found in ', u'Found ')):
+            out_stream = sys.stderr
+        else:
+            out_stream = sys.stdout
+
+        print(line, file=out_stream)
+
+    return return_code
+
+
+def main():
+    """Validate type annotations with mypy against Python 2 and 3."""
+    target_pythons = '3.9', '3.6', '2.7'
+    return_code = sum(run_mypy(py_ver) for py_ver in target_pythons)
+    return return_code
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/test/sanity/code-smell/mypy.py
+++ b/test/sanity/code-smell/mypy.py
@@ -17,8 +17,11 @@ def run_mypy(python_version=None):
             () if python_version is None
             else ('--python-version', python_version)
         ),
+        # 'hacking/shippable/incidental.py',
         'lib/ansible/galaxy/collection/',
         'lib/ansible/galaxy/dependency_resolution',
+        # 'test/lib/ansible_test/_internal',
+        # 'test/utils/shippable/check_matrix.py',
     )
     try:
         mypy_out = subprocess.check_output(mypy_cmd, universal_newlines=True)

--- a/test/sanity/code-smell/mypy.requirements.txt
+++ b/test/sanity/code-smell/mypy.requirements.txt
@@ -1,0 +1,3 @@
+mypy
+typing
+typing-extensions

--- a/test/sanity/code-smell/package-data.requirements.txt
+++ b/test/sanity/code-smell/package-data.requirements.txt
@@ -2,6 +2,7 @@ docutils
 jinja2
 packaging
 pyyaml  # ansible-core requirement
+resolvelib  # ansible-core requirement
 rstcheck
 setuptools > 39.2
 straight.plugin

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -43,6 +43,8 @@ lib/ansible/executor/powershell/exec_wrapper.ps1 pslint:PSCustomUseLiteralPath
 lib/ansible/executor/task_queue_manager.py pylint:blacklisted-name
 lib/ansible/galaxy/collection/__init__.py compile-2.6!skip # 'ansible-galaxy collection' requires 2.7+
 lib/ansible/galaxy/collection/galaxy_api_proxy.py compile-2.6!skip  # 'ansible-galaxy collection' requires 2.7+
+lib/ansible/galaxy/dependency_resolution/dataclasses.py compile-2.6!skip  # 'ansible-galaxy collection' requires 2.7+
+lib/ansible/galaxy/dependency_resolution/providers.py compile-2.6!skip  # 'ansible-galaxy collection' requires 2.7+
 lib/ansible/module_utils/compat/_selectors2.py future-import-boilerplate # ignore bundled
 lib/ansible/module_utils/compat/_selectors2.py metaclass-boilerplate # ignore bundled
 lib/ansible/module_utils/compat/_selectors2.py pylint:blacklisted-name

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -41,6 +41,7 @@ lib/ansible/executor/powershell/async_watchdog.ps1 pslint:PSCustomUseLiteralPath
 lib/ansible/executor/powershell/async_wrapper.ps1 pslint:PSCustomUseLiteralPath
 lib/ansible/executor/powershell/exec_wrapper.ps1 pslint:PSCustomUseLiteralPath
 lib/ansible/executor/task_queue_manager.py pylint:blacklisted-name
+lib/ansible/cli/galaxy.py compile-2.6!skip  # 'ansible-galaxy collection' requires 2.7+
 lib/ansible/galaxy/collection/__init__.py compile-2.6!skip # 'ansible-galaxy collection' requires 2.7+
 lib/ansible/galaxy/collection/galaxy_api_proxy.py compile-2.6!skip  # 'ansible-galaxy collection' requires 2.7+
 lib/ansible/galaxy/dependency_resolution/dataclasses.py compile-2.6!skip  # 'ansible-galaxy collection' requires 2.7+

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -42,6 +42,7 @@ lib/ansible/executor/powershell/async_wrapper.ps1 pslint:PSCustomUseLiteralPath
 lib/ansible/executor/powershell/exec_wrapper.ps1 pslint:PSCustomUseLiteralPath
 lib/ansible/executor/task_queue_manager.py pylint:blacklisted-name
 lib/ansible/galaxy/collection/__init__.py compile-2.6!skip # 'ansible-galaxy collection' requires 2.7+
+lib/ansible/galaxy/collection/galaxy_api_proxy.py compile-2.6!skip  # 'ansible-galaxy collection' requires 2.7+
 lib/ansible/module_utils/compat/_selectors2.py future-import-boilerplate # ignore bundled
 lib/ansible/module_utils/compat/_selectors2.py metaclass-boilerplate # ignore bundled
 lib/ansible/module_utils/compat/_selectors2.py pylint:blacklisted-name

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -204,6 +204,11 @@ test/lib/ansible_test/_data/requirements/sanity.ps1 pslint:PSCustomUseLiteralPat
 test/lib/ansible_test/_data/sanity/pylint/plugins/string_format.py use-compat-six
 test/lib/ansible_test/_data/setup/ConfigureRemotingForAnsible.ps1 pslint:PSCustomUseLiteralPath
 test/lib/ansible_test/_data/setup/windows-httptester.ps1 pslint:PSCustomUseLiteralPath
+test/sanity/code-smell/mypy.py compile-2.6!skip  # it's invoked under py3.6
+test/sanity/code-smell/mypy.py compile-2.7!skip  # it's invoked under py3.6
+test/sanity/code-smell/mypy.py compile-3.5!skip  # it's invoked under py3.6
+test/sanity/code-smell/mypy.py future-import-boilerplate!skip  # it's invoked under py3.6
+test/sanity/code-smell/mypy.py metaclass-boilerplate!skip  # it's invoked under py3.6
 test/support/integration/plugins/module_utils/cloud.py future-import-boilerplate
 test/support/integration/plugins/module_utils/cloud.py metaclass-boilerplate
 test/support/integration/plugins/module_utils/compat/ipaddress.py future-import-boilerplate

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -223,7 +223,7 @@ def mock_collection(galaxy_server):
 
 def test_build_collection_no_galaxy_yaml():
     fake_path = u'/fake/ÅÑŚÌβŁÈ/path'
-    expected = to_native("The collection galaxy.yml path '%s/galaxy.yml' does not exist." % fake_path)
+    expected = to_native("The collection galaxy.yml path '%s' does not exist." % fake_path)
 
     with pytest.raises(AnsibleError, match=expected):
         collection.build_collection(fake_path, 'output', False)
@@ -673,7 +673,7 @@ def test_download_file(tmp_path_factory, monkeypatch):
     mock_open.return_value = BytesIO(data)
     monkeypatch.setattr(collection.concrete_artifact_manager, 'open_url', mock_open)
 
-    expected = os.path.join(temp_dir, b'file')
+    expected = temp_dir
     actual = collection._download_file('http://google.com/file', temp_dir, sha256_hash.hexdigest(), True)
 
     assert actual.startswith(expected)
@@ -775,7 +775,8 @@ def test_require_one_of_collections_requirements_with_collections():
 
     requirements = cli._require_one_of_collections_requirements(collections, '')['collections']
 
-    assert requirements == [('namespace1.collection1', '*', None, None), ('namespace2.collection1', '1.0.0', None, None)]
+    req_tuples = [('%s.%s' % (req.namespace, req.name), req.ver, req.src, req.type,) for req in requirements]
+    assert req_tuples == [('namespace1.collection1', '*', None, 'galaxy'), ('namespace2.collection1', '1.0.0', None, 'galaxy')]
 
 
 @patch('ansible.cli.galaxy.GalaxyCLI._parse_requirements_file')

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -234,7 +234,7 @@ def test_build_existing_output_file(collection_input):
     expected = "The output collection artifact '%s' already exists, but is a directory - aborting" \
                % to_native(existing_output_dir)
     with pytest.raises(AnsibleError, match=expected):
-        collection.build_collection(input_dir, output_dir, False)
+        collection.build_collection(input_dir, to_bytes(output_dir, errors='surrogate_or_strict'), False)
 
 
 def test_build_existing_output_without_force(collection_input):
@@ -248,7 +248,7 @@ def test_build_existing_output_without_force(collection_input):
     expected = "The file '%s' already exists. You can use --force to re-create the collection artifact." \
                % to_native(existing_output)
     with pytest.raises(AnsibleError, match=expected):
-        collection.build_collection(input_dir, output_dir, False)
+        collection.build_collection(input_dir, to_bytes(output_dir, errors='surrogate_or_strict'), False)
 
 
 def test_build_existing_output_with_force(collection_input):
@@ -259,7 +259,7 @@ def test_build_existing_output_with_force(collection_input):
         out_file.write("random garbage")
         out_file.flush()
 
-    collection.build_collection(input_dir, output_dir, True)
+    collection.build_collection(input_dir, to_bytes(output_dir, errors='surrogate_or_strict'), True)
 
     # Verify the file was replaced with an actual tar file
     assert tarfile.is_tarfile(existing_output)
@@ -529,7 +529,7 @@ def test_build_with_symlink_inside_collection(collection_input):
     os.symlink(roles_target, roles_link)
     os.symlink(os.path.join(input_dir, 'README.md'), file_link)
 
-    collection.build_collection(input_dir, output_dir, False)
+    collection.build_collection(input_dir, to_bytes(output_dir, errors='surrogate_or_strict'), False)
 
     output_artifact = os.path.join(output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
     assert tarfile.is_tarfile(output_artifact)

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -60,7 +60,7 @@ def collection_input(tmp_path_factory):
 def collection_artifact(monkeypatch, tmp_path_factory):
     ''' Creates a temp collection artifact and mocked open_url instance for publishing tests '''
     mock_open = MagicMock()
-    monkeypatch.setattr(collection, 'open_url', mock_open)
+    monkeypatch.setattr(collection.concrete_artifact_manager, 'open_url', mock_open)
 
     mock_uuid = MagicMock()
     mock_uuid.return_value.hex = 'uuid'
@@ -672,7 +672,7 @@ def test_download_file(tmp_path_factory, monkeypatch):
 
     mock_open = MagicMock()
     mock_open.return_value = BytesIO(data)
-    monkeypatch.setattr(collection, 'open_url', mock_open)
+    monkeypatch.setattr(collection.concrete_artifact_manager, 'open_url', mock_open)
 
     expected = os.path.join(temp_dir, b'file')
     actual = collection._download_file('http://google.com/file', temp_dir, sha256_hash.hexdigest(), True)
@@ -693,7 +693,7 @@ def test_download_file_hash_mismatch(tmp_path_factory, monkeypatch):
 
     mock_open = MagicMock()
     mock_open.return_value = BytesIO(data)
-    monkeypatch.setattr(collection, 'open_url', mock_open)
+    monkeypatch.setattr(collection.concrete_artifact_manager, 'open_url', mock_open)
 
     expected = "Mismatch artifact hash with downloaded file"
     with pytest.raises(AnsibleError, match=expected):

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -28,10 +28,6 @@ from ansible.utils.display import Display
 from ansible.utils.hashing import secure_hash_s
 
 
-# FIXME: define collection.CollectionRequirement just so the unfixed tests don't impede running the rest
-collection.CollectionRequirement = None
-
-
 @pytest.fixture(autouse='function')
 def reset_cli_args():
     co.GlobalCLIArgs._Singleton__instance = None
@@ -200,25 +196,6 @@ def manifest(manifest_info):
     with patch.object(builtins, 'open', mock_open(read_data=b_data)) as m:
         with open('MANIFEST.json', mode='rb') as fake_file:
             yield fake_file, sha256(b_data).hexdigest()
-
-
-@pytest.fixture()
-def mock_collection(galaxy_server):
-    def create_mock_collection(namespace='ansible_namespace', name='collection', version='0.1.0', local=True, local_installed=True):
-        b_path = None
-        force = False
-
-        if local:
-            mock_collection = collection.CollectionRequirement(namespace, name, b_path, galaxy_server, [version], version, force, skip=local_installed)
-        else:
-            download_url = 'https://galaxy.ansible.com/download/{0}-{1}-{2}.tar.gz'.format(namespace, name, version)
-            digest = '19415a6a6df831df61cffde4a09d1d89ac8d8ca5c0586e85bea0b106d6dff29a'
-            dependencies = {}
-            metadata = api.CollectionVersionMetadata(namespace, name, version, download_url, digest, dependencies)
-            mock_collection = collection.CollectionRequirement(namespace, name, b_path, galaxy_server, [version], version, force, metadata=metadata)
-
-        return mock_collection
-    return create_mock_collection
 
 
 def test_build_collection_no_galaxy_yaml():
@@ -825,13 +802,13 @@ def test_execute_verify_with_defaults(mock_verify_collections):
 
     assert mock_verify_collections.call_count == 1
 
-    requirements, search_paths, galaxy_apis, validate, ignore_errors = mock_verify_collections.call_args[0]
+    print("Call args {0}".format(mock_verify_collections.call_args[0]))
+    requirements, search_paths, galaxy_apis, ignore_errors = mock_verify_collections.call_args[0]
 
-    assert requirements == [('namespace.collection', '1.0.4', None, None)]
+    assert [('%s.%s' % (r.namespace, r.name), r.ver, r.src, r.type) for r in requirements] == [('namespace.collection', '1.0.4', None, 'galaxy')]
     for install_path in search_paths:
         assert install_path.endswith('ansible_collections')
     assert galaxy_apis[0].api_server == 'https://galaxy.ansible.com'
-    assert validate is True
     assert ignore_errors is False
 
 
@@ -844,13 +821,12 @@ def test_execute_verify(mock_verify_collections):
 
     assert mock_verify_collections.call_count == 1
 
-    requirements, search_paths, galaxy_apis, validate, ignore_errors = mock_verify_collections.call_args[0]
+    requirements, search_paths, galaxy_apis, ignore_errors = mock_verify_collections.call_args[0]
 
-    assert requirements == [('namespace.collection', '1.0.4', None, None)]
+    assert [('%s.%s' % (r.namespace, r.name), r.ver, r.src, r.type) for r in requirements] == [('namespace.collection', '1.0.4', None, 'galaxy')]
     for install_path in search_paths:
         assert install_path.endswith('ansible_collections')
     assert galaxy_apis[0].api_server == 'http://galaxy-dev.com'
-    assert validate is False
     assert ignore_errors is True
 
 
@@ -867,8 +843,7 @@ def test_verify_file_hash_deleted_file(manifest_info):
 
     with patch.object(builtins, 'open', mock_open(read_data=data)) as m:
         with patch.object(collection.os.path, 'isfile', MagicMock(return_value=False)) as mock_isfile:
-            collection_req = collection.CollectionRequirement(namespace, name, './', server, [version], version, False)
-            collection_req._verify_file_hash(b'path/', 'file', digest, error_queue)
+            collection._verify_file_hash(b'path/', 'file', digest, error_queue)
 
             assert mock_isfile.called_once
 
@@ -891,8 +866,7 @@ def test_verify_file_hash_matching_hash(manifest_info):
 
     with patch.object(builtins, 'open', mock_open(read_data=data)) as m:
         with patch.object(collection.os.path, 'isfile', MagicMock(return_value=True)) as mock_isfile:
-            collection_req = collection.CollectionRequirement(namespace, name, './', server, [version], version, False)
-            collection_req._verify_file_hash(b'path/', 'file', digest, error_queue)
+            collection._verify_file_hash(b'path/', 'file', digest, error_queue)
 
             assert mock_isfile.called_once
 
@@ -914,8 +888,7 @@ def test_verify_file_hash_mismatching_hash(manifest_info):
 
     with patch.object(builtins, 'open', mock_open(read_data=data)) as m:
         with patch.object(collection.os.path, 'isfile', MagicMock(return_value=True)) as mock_isfile:
-            collection_req = collection.CollectionRequirement(namespace, name, './', server, [version], version, False)
-            collection_req._verify_file_hash(b'path/', 'file', different_digest, error_queue)
+            collection._verify_file_hash(b'path/', 'file', different_digest, error_queue)
 
             assert mock_isfile.called_once
 
@@ -976,355 +949,3 @@ def test_get_json_from_tar_file(tmp_tarfile):
     data = collection._get_json_from_tar_file(tfile.name, 'MANIFEST.json')
 
     assert isinstance(data, dict)
-
-
-def test_verify_collection_not_installed(mock_collection):
-
-    local_collection = mock_collection(local_installed=False)
-    remote_collection = mock_collection(local=False)
-
-    with patch.object(collection.display, 'display') as mocked_display:
-        local_collection.verify(remote_collection, './', './')
-
-        assert mocked_display.called
-        assert mocked_display.call_args[0][0] == "'%s.%s' has not been installed, nothing to verify" % (local_collection.namespace, local_collection.name)
-
-
-def test_verify_successful_debug_info(monkeypatch, mock_collection):
-    local_collection = mock_collection()
-    remote_collection = mock_collection(local=False)
-
-    monkeypatch.setattr(collection, '_get_tar_file_hash', MagicMock())
-    monkeypatch.setattr(collection.CollectionRequirement, '_verify_file_hash', MagicMock())
-    monkeypatch.setattr(collection, '_get_json_from_tar_file', MagicMock())
-
-    with patch.object(collection.display, 'vvv') as mock_display:
-        local_collection.verify(remote_collection, './', './')
-
-        namespace = local_collection.namespace
-        name = local_collection.name
-        version = local_collection.latest_version
-
-        assert mock_display.call_count == 4
-        assert mock_display.call_args_list[0][0][0] == "Verifying '%s.%s:%s'." % (namespace, name, version)
-        assert mock_display.call_args_list[1][0][0] == "Installed collection found at './%s/%s'" % (namespace, name)
-        located = "Remote collection found at 'https://galaxy.ansible.com/download/%s-%s-%s.tar.gz'" % (namespace, name, version)
-        assert mock_display.call_args_list[2][0][0] == located
-        verified = "Successfully verified that checksums for '%s.%s:%s' match the remote collection" % (namespace, name, version)
-        assert mock_display.call_args_list[3][0][0] == verified
-
-
-def test_verify_different_versions(mock_collection):
-
-    local_collection = mock_collection(version='0.1.0')
-    remote_collection = mock_collection(local=False, version='3.0.0')
-
-    with patch.object(collection.display, 'display') as mock_display:
-        local_collection.verify(remote_collection, './', './')
-
-        namespace = local_collection.namespace
-        name = local_collection.name
-        installed_version = local_collection.latest_version
-        compared_version = remote_collection.latest_version
-
-        msg = "%s.%s has the version '%s' but is being compared to '%s'" % (namespace, name, installed_version, compared_version)
-
-        assert mock_display.call_count == 1
-        assert mock_display.call_args[0][0] == msg
-
-
-@patch.object(builtins, 'open', mock_open())
-def test_verify_modified_manifest(monkeypatch, mock_collection, manifest_info):
-    local_collection = mock_collection()
-    remote_collection = mock_collection(local=False)
-
-    monkeypatch.setattr(collection, '_get_tar_file_hash', MagicMock(side_effect=['manifest_checksum']))
-    monkeypatch.setattr(collection, '_consume_file', MagicMock(side_effect=['manifest_checksum_modified', 'files_manifest_checksum']))
-    monkeypatch.setattr(collection, '_get_json_from_tar_file', MagicMock(side_effect=[manifest_info, {'files': []}]))
-    monkeypatch.setattr(collection.os.path, 'isfile', MagicMock(return_value=True))
-
-    with patch.object(collection.display, 'display') as mock_display:
-        with patch.object(collection.display, 'vvv') as mock_debug:
-            local_collection.verify(remote_collection, './', './')
-
-            namespace = local_collection.namespace
-            name = local_collection.name
-
-            assert mock_display.call_count == 3
-            assert mock_display.call_args_list[0][0][0] == 'Collection %s.%s contains modified content in the following files:' % (namespace, name)
-            assert mock_display.call_args_list[1][0][0] == '%s.%s' % (namespace, name)
-            assert mock_display.call_args_list[2][0][0] == '    MANIFEST.json'
-
-            # The -vvv output should show details (the checksums do not match)
-            assert mock_debug.call_count == 5
-            assert mock_debug.call_args_list[-1][0][0] == '    Expected: manifest_checksum\n    Found: manifest_checksum_modified'
-
-
-@patch.object(builtins, 'open', mock_open())
-def test_verify_modified_files_manifest(monkeypatch, mock_collection, manifest_info):
-    local_collection = mock_collection()
-    remote_collection = mock_collection(local=False)
-
-    monkeypatch.setattr(collection, '_get_tar_file_hash', MagicMock(side_effect=['manifest_checksum']))
-    monkeypatch.setattr(collection, '_consume_file', MagicMock(side_effect=['manifest_checksum', 'files_manifest_checksum_modified']))
-    monkeypatch.setattr(collection, '_get_json_from_tar_file', MagicMock(side_effect=[manifest_info, {'files': []}]))
-    monkeypatch.setattr(collection.os.path, 'isfile', MagicMock(return_value=True))
-
-    with patch.object(collection.display, 'display') as mock_display:
-        with patch.object(collection.display, 'vvv') as mock_debug:
-            local_collection.verify(remote_collection, './', './')
-
-            namespace = local_collection.namespace
-            name = local_collection.name
-
-            assert mock_display.call_count == 3
-            assert mock_display.call_args_list[0][0][0] == 'Collection %s.%s contains modified content in the following files:' % (namespace, name)
-            assert mock_display.call_args_list[1][0][0] == '%s.%s' % (namespace, name)
-            assert mock_display.call_args_list[2][0][0] == '    FILES.json'
-
-            # The -vvv output should show details (the checksums do not match)
-            assert mock_debug.call_count == 5
-            assert mock_debug.call_args_list[-1][0][0] == '    Expected: files_manifest_checksum\n    Found: files_manifest_checksum_modified'
-
-
-@patch.object(builtins, 'open', mock_open())
-def test_verify_modified_files(monkeypatch, mock_collection, manifest_info, files_manifest_info):
-
-    local_collection = mock_collection()
-    remote_collection = mock_collection(local=False)
-
-    monkeypatch.setattr(collection, '_get_tar_file_hash', MagicMock(side_effect=['manifest_checksum']))
-    fakehashes = ['manifest_checksum', 'files_manifest_checksum', 'individual_file_checksum_modified']
-    monkeypatch.setattr(collection, '_consume_file', MagicMock(side_effect=fakehashes))
-    monkeypatch.setattr(collection, '_get_json_from_tar_file', MagicMock(side_effect=[manifest_info, files_manifest_info]))
-    monkeypatch.setattr(collection.os.path, 'isfile', MagicMock(return_value=True))
-
-    with patch.object(collection.display, 'display') as mock_display:
-        with patch.object(collection.display, 'vvv') as mock_debug:
-            local_collection.verify(remote_collection, './', './')
-
-            namespace = local_collection.namespace
-            name = local_collection.name
-
-            assert mock_display.call_count == 3
-            assert mock_display.call_args_list[0][0][0] == 'Collection %s.%s contains modified content in the following files:' % (namespace, name)
-            assert mock_display.call_args_list[1][0][0] == '%s.%s' % (namespace, name)
-            assert mock_display.call_args_list[2][0][0] == '    README.md'
-
-            # The -vvv output should show details (the checksums do not match)
-            assert mock_debug.call_count == 5
-            assert mock_debug.call_args_list[-1][0][0] == '    Expected: individual_file_checksum\n    Found: individual_file_checksum_modified'
-
-
-@patch.object(builtins, 'open', mock_open())
-def test_verify_identical(monkeypatch, mock_collection, manifest_info, files_manifest_info):
-
-    local_collection = mock_collection()
-    remote_collection = mock_collection(local=False)
-
-    monkeypatch.setattr(collection, '_get_tar_file_hash', MagicMock(side_effect=['manifest_checksum']))
-    monkeypatch.setattr(collection, '_consume_file', MagicMock(side_effect=['manifest_checksum', 'files_manifest_checksum', 'individual_file_checksum']))
-    monkeypatch.setattr(collection, '_get_json_from_tar_file', MagicMock(side_effect=[manifest_info, files_manifest_info]))
-    monkeypatch.setattr(collection.os.path, 'isfile', MagicMock(return_value=True))
-
-    with patch.object(collection.display, 'display') as mock_display:
-        with patch.object(collection.display, 'vvv') as mock_debug:
-            local_collection.verify(remote_collection, './', './')
-
-            # Successful verification is quiet
-            assert mock_display.call_count == 0
-
-            # The -vvv output should show the checksums not matching
-            namespace = local_collection.namespace
-            name = local_collection.name
-            version = local_collection.latest_version
-            success_msg = "Successfully verified that checksums for '%s.%s:%s' match the remote collection" % (namespace, name, version)
-
-            assert mock_debug.call_count == 4
-            assert mock_debug.call_args_list[-1][0][0] == success_msg
-
-
-@patch.object(os.path, 'isdir', return_value=True)
-def test_verify_collections_no_version(mock_isdir, mock_collection, monkeypatch):
-    namespace = 'ansible_namespace'
-    name = 'collection'
-    version = '*'  # Occurs if MANIFEST.json does not exist
-
-    local_collection = mock_collection(namespace=namespace, name=name, version=version)
-    monkeypatch.setattr(collection.CollectionRequirement, 'from_path', MagicMock(return_value=local_collection))
-
-    collections = [('%s.%s' % (namespace, name), version, None)]
-
-    with pytest.raises(AnsibleError) as err:
-        collection.verify_collections(collections, './', local_collection.api, False, False)
-
-    err_msg = 'Collection %s.%s does not appear to have a MANIFEST.json. ' % (namespace, name)
-    err_msg += 'A MANIFEST.json is expected if the collection has been built and installed via ansible-galaxy.'
-    assert err.value.message == err_msg
-
-
-@patch.object(collection.CollectionRequirement, 'verify')
-def test_verify_collections_not_installed(mock_verify, mock_collection, monkeypatch):
-    namespace = 'ansible_namespace'
-    name = 'collection'
-    version = '1.0.0'
-
-    local_collection = mock_collection(local_installed=False)
-
-    found_remote = MagicMock(return_value=mock_collection(local=False))
-    monkeypatch.setattr(collection.CollectionRequirement, 'from_name', found_remote)
-
-    collections = [('%s.%s' % (namespace, name), version, None, None)]
-    search_path = './'
-    validate_certs = False
-    ignore_errors = False
-    apis = [local_collection.api]
-
-    with patch.object(collection, '_download_file') as mock_download_file:
-        with pytest.raises(AnsibleError) as err:
-            collection.verify_collections(collections, search_path, apis, validate_certs, ignore_errors)
-
-    assert err.value.message == "Collection %s.%s is not installed in any of the collection paths." % (namespace, name)
-
-
-@patch.object(collection.CollectionRequirement, 'verify')
-def test_verify_collections_not_installed_ignore_errors(mock_verify, mock_collection, monkeypatch):
-    namespace = 'ansible_namespace'
-    name = 'collection'
-    version = '1.0.0'
-
-    local_collection = mock_collection(local_installed=False)
-
-    found_remote = MagicMock(return_value=mock_collection(local=False))
-    monkeypatch.setattr(collection.CollectionRequirement, 'from_name', found_remote)
-
-    collections = [('%s.%s' % (namespace, name), version, None)]
-    search_path = './'
-    validate_certs = False
-    ignore_errors = True
-    apis = [local_collection.api]
-
-    with patch.object(collection, '_download_file') as mock_download_file:
-        with patch.object(Display, 'warning') as mock_warning:
-            collection.verify_collections(collections, search_path, apis, validate_certs, ignore_errors)
-
-            skip_message = "Failed to verify collection %s.%s but skipping due to --ignore-errors being set." % (namespace, name)
-            original_err = "Error: Collection %s.%s is not installed in any of the collection paths." % (namespace, name)
-
-            assert mock_warning.called
-            assert mock_warning.call_args[0][0] == skip_message + " " + original_err
-
-
-@patch.object(os.path, 'isdir', return_value=True)
-@patch.object(collection.CollectionRequirement, 'verify')
-def test_verify_collections_no_remote(mock_verify, mock_isdir, mock_collection, monkeypatch):
-    namespace = 'ansible_namespace'
-    name = 'collection'
-    version = '1.0.0'
-
-    monkeypatch.setattr(os.path, 'isfile', MagicMock(side_effect=[False, True]))
-    monkeypatch.setattr(collection.CollectionRequirement, 'from_path', MagicMock(return_value=mock_collection()))
-
-    collections = [('%s.%s' % (namespace, name), version, None)]
-    search_path = './'
-    validate_certs = False
-    ignore_errors = False
-    apis = []
-
-    with pytest.raises(AnsibleError) as err:
-        collection.verify_collections(collections, search_path, apis, validate_certs, ignore_errors)
-
-    assert err.value.message == "Failed to find remote collection %s.%s:%s on any of the galaxy servers" % (namespace, name, version)
-
-
-@patch.object(os.path, 'isdir', return_value=True)
-@patch.object(collection.CollectionRequirement, 'verify')
-def test_verify_collections_no_remote_ignore_errors(mock_verify, mock_isdir, mock_collection, monkeypatch):
-    namespace = 'ansible_namespace'
-    name = 'collection'
-    version = '1.0.0'
-
-    monkeypatch.setattr(os.path, 'isfile', MagicMock(side_effect=[False, True]))
-    monkeypatch.setattr(collection.CollectionRequirement, 'from_path', MagicMock(return_value=mock_collection()))
-
-    collections = [('%s.%s' % (namespace, name), version, None)]
-    search_path = './'
-    validate_certs = False
-    ignore_errors = True
-    apis = []
-
-    with patch.object(Display, 'warning') as mock_warning:
-        collection.verify_collections(collections, search_path, apis, validate_certs, ignore_errors)
-
-        skip_message = "Failed to verify collection %s.%s but skipping due to --ignore-errors being set." % (namespace, name)
-        original_err = "Error: Failed to find remote collection %s.%s:%s on any of the galaxy servers" % (namespace, name, version)
-
-        assert mock_warning.called
-        assert mock_warning.call_args[0][0] == skip_message + " " + original_err
-
-
-def test_verify_collections_tarfile(monkeypatch):
-
-    monkeypatch.setattr(os.path, 'isfile', MagicMock(return_value=True))
-
-    invalid_format = 'ansible_namespace-collection-0.1.0.tar.gz'
-    collections = [(invalid_format, '*', None)]
-
-    with pytest.raises(AnsibleError) as err:
-        collection.verify_collections(collections, './', [], False, False)
-
-    msg = "'%s' is not a valid collection name. The format namespace.name is expected." % invalid_format
-    assert err.value.message == msg
-
-
-def test_verify_collections_path(monkeypatch):
-
-    monkeypatch.setattr(os.path, 'isfile', MagicMock(return_value=False))
-
-    invalid_format = 'collections/collection_namespace/collection_name'
-    collections = [(invalid_format, '*', None)]
-
-    with pytest.raises(AnsibleError) as err:
-        collection.verify_collections(collections, './', [], False, False)
-
-    msg = "'%s' is not a valid collection name. The format namespace.name is expected." % invalid_format
-    assert err.value.message == msg
-
-
-def test_verify_collections_url(monkeypatch):
-
-    monkeypatch.setattr(os.path, 'isfile', MagicMock(return_value=False))
-
-    invalid_format = 'https://galaxy.ansible.com/download/ansible_namespace-collection-0.1.0.tar.gz'
-    collections = [(invalid_format, '*', None)]
-
-    with pytest.raises(AnsibleError) as err:
-        collection.verify_collections(collections, './', [], False, False)
-
-    msg = "'%s' is not a valid collection name. The format namespace.name is expected." % invalid_format
-    assert err.value.message == msg
-
-
-@patch.object(os.path, 'isdir', return_value=True)
-@patch.object(collection.CollectionRequirement, 'verify')
-def test_verify_collections_name(mock_verify, mock_isdir, mock_collection, monkeypatch):
-    local_collection = mock_collection()
-    monkeypatch.setattr(collection.CollectionRequirement, 'from_path', MagicMock(return_value=local_collection))
-
-    monkeypatch.setattr(os.path, 'isfile', MagicMock(side_effect=[False, True, False]))
-
-    located_remote_from_name = MagicMock(return_value=mock_collection(local=False))
-    monkeypatch.setattr(collection.CollectionRequirement, 'from_name', located_remote_from_name)
-
-    with patch.object(collection, '_download_file') as mock_download_file:
-
-        collections = [('%s.%s' % (local_collection.namespace, local_collection.name), '%s' % local_collection.latest_version, None)]
-        search_path = './'
-        validate_certs = False
-        ignore_errors = False
-        apis = [local_collection.api]
-
-        collection.verify_collections(collections, search_path, apis, validate_certs, ignore_errors)
-
-        assert mock_download_file.call_count == 1
-        assert located_remote_from_name.call_count == 1

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -28,6 +28,10 @@ from ansible.utils.display import Display
 from ansible.utils.hashing import secure_hash_s
 
 
+# FIXME: define collection.CollectionRequirement just so the unfixed tests don't impede running the rest
+collection.CollectionRequirement = None
+
+
 @pytest.fixture(autouse='function')
 def reset_cli_args():
     co.GlobalCLIArgs._Singleton__instance = None

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -223,7 +223,7 @@ def mock_collection(galaxy_server):
 
 def test_build_collection_no_galaxy_yaml():
     fake_path = u'/fake/ÅÑŚÌβŁÈ/path'
-    expected = to_native("The collection galaxy.yml path '%s' does not exist." % fake_path)
+    expected = to_native("The collection galaxy.yml path '%s/galaxy.yml' does not exist." % fake_path)
 
     with pytest.raises(AnsibleError, match=expected):
         collection.build_collection(fake_path, 'output', False)


### PR DESCRIPTION
Some fixes for getting the install integration tests to pass. There are 2 outstanding issues I came across that will need to be fixed still

* `collection list` currently fails when coming across a dir that doesn't have a `galaxy.yml` or `MANIFEST.json`.
  * devel behaviour outputs an error and just treats the version as `*`
  * current PR behaviour stop the execution and fails
* when selecting the server to download from when the collection exists on muiltiple the select that is actually selected should be the first one in the `server_list`
  * current tests at https://github.com/webknjaz/ansible/compare/features/71784--resolvelib-collections-dep-resolver...jborean93:galaxy-resolver?expand=1#diff-e8f1119c538b4892135a92da1e3f1c523f2b1cd7658d7ebd975b19761c475187R151 are commented out until this is fixed